### PR TITLE
reorganize api resources

### DIFF
--- a/lsproxy/src/handlers/definition.rs
+++ b/lsproxy/src/handlers/definition.rs
@@ -32,7 +32,7 @@ use lsp_types::{
 /// ```
 #[utoipa::path(
     post,
-    path = "/definition",
+    path = "/symbol/find-definition",
     tag = "symbol",
     request_body = GetDefinitionRequest,
     responses(

--- a/lsproxy/src/handlers/file_symbols.rs
+++ b/lsproxy/src/handlers/file_symbols.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 /// ```
 #[utoipa::path(
     get,
-    path = "/file-symbols",
+    path = "/symbol/definitions-in-file",
     tag = "symbol",
     params(FileSymbolsRequest),
     responses(

--- a/lsproxy/src/handlers/references.rs
+++ b/lsproxy/src/handlers/references.rs
@@ -31,7 +31,7 @@ use crate::AppState;
 /// ```
 #[utoipa::path(
     post,
-    path = "/references",
+    path = "/symbol/find-references",
     tag = "symbol",
     request_body = GetReferencesRequest,
     responses(

--- a/lsproxy/src/handlers/workspace_files.rs
+++ b/lsproxy/src/handlers/workspace_files.rs
@@ -13,7 +13,7 @@ use crate::AppState;
 /// This is a convenience endpoint that does not use the underlying Language Servers directly, but it does apply the same filtering.
 #[utoipa::path(
     get,
-    path = "/workspace-files",
+    path = "/workspace/list-files",
     tag = "workspace",
     responses(
         (status = 200, description = "Workspace files retrieved successfully", body = Vec<String>),

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -94,10 +94,16 @@ pub async fn run_server(app_state: Data<AppState>) -> std::io::Result<()> {
             )
             .service(
                 scope("/v1")
-                    .service(resource("/file-symbols").route(get().to(file_symbols)))
-                    .service(resource("/definition").route(post().to(definition)))
-                    .service(resource("/references").route(post().to(references)))
-                    .service(resource("/workspace-files").route(get().to(workspace_files))),
+                    .service(
+                        scope("/symbol")
+                            .service(resource("/definitions-in-file").route(get().to(file_symbols)))
+                            .service(resource("/find-definition").route(post().to(definition)))
+                            .service(resource("/find-references").route(post().to(references)))
+                    )
+                    .service(
+                        scope("/workspace")
+                            .service(resource("/list-files").route(get().to(workspace_files)))
+                    ),
             )
     })
     .bind("0.0.0.0:4444")?

--- a/openapi.json
+++ b/openapi.json
@@ -15,45 +15,7 @@
     }
   ],
   "paths": {
-    "/definition": {
-      "post": {
-        "tags": [
-          "symbol"
-        ],
-        "summary": "Get the definition of a symbol at a specific position in a file",
-        "description": "Get the definition of a symbol at a specific position in a file\n\nReturns the location of the definition for the symbol at the given position.\n\nThe input position should point inside the symbol's identifier, e.g.\n\nThe returned position points to the identifier of the symbol, and the file_path from workspace root\n\ne.g. for the definition of `User` on line 5 of `src/main.py` with the code:\n```\n0: class User:\noutput___^\n1:     def __init__(self, name, age):\n2:         self.name = name\n3:         self.age = age\n4:\n5: user = User(\"John\", 30)\ninput_____^^^^\n```",
-        "operationId": "definition",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GetDefinitionRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Definition retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DefinitionResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
-    "/file-symbols": {
+    "/symbol/definitions-in-file": {
       "get": {
         "tags": [
           "symbol"
@@ -101,7 +63,45 @@
         }
       }
     },
-    "/references": {
+    "/symbol/find-definition": {
+      "post": {
+        "tags": [
+          "symbol"
+        ],
+        "summary": "Get the definition of a symbol at a specific position in a file",
+        "description": "Get the definition of a symbol at a specific position in a file\n\nReturns the location of the definition for the symbol at the given position.\n\nThe input position should point inside the symbol's identifier, e.g.\n\nThe returned position points to the identifier of the symbol, and the file_path from workspace root\n\ne.g. for the definition of `User` on line 5 of `src/main.py` with the code:\n```\n0: class User:\noutput___^\n1:     def __init__(self, name, age):\n2:         self.name = name\n3:         self.age = age\n4:\n5: user = User(\"John\", 30)\ninput_____^^^^\n```",
+        "operationId": "definition",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetDefinitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Definition retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefinitionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/symbol/find-references": {
       "post": {
         "tags": [
           "symbol"
@@ -139,7 +139,7 @@
         }
       }
     },
-    "/workspace-files": {
+    "/workspace/list-files": {
       "get": {
         "tags": [
           "workspace"


### PR DESCRIPTION
## **Description**
- Updated API paths for better organization and clarity:
  - Changed `/definition` to `/symbol/find-definition`.
  - Changed `/file-symbols` to `/symbol/definitions-in-file`.
  - Changed `/references` to `/symbol/find-references`.
  - Changed `/workspace-files` to `/workspace/list-files`.
- Reorganized API service scopes in the server configuration.
- Updated OpenAPI documentation to reflect new API paths.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>definition.rs</strong><dd><code>Update API path for symbol definition retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/definition.rs
- Updated API path from `/definition` to `/symbol/find-definition`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-97d644b2c521177acd4bcb0ba381ba91de644bd82c60888a34889a3d16ccedaa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>file_symbols.rs</strong><dd><code>Update API path for file symbol definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/file_symbols.rs
<li>Updated API path from <code>/file-symbols</code> to <code>/symbol/definitions-in-file</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-f6bcfa0f43b424459f1e8c75e85405810b987ea94efebd63e76e48a0514e92b1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>references.rs</strong><dd><code>Update API path for finding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/references.rs
- Updated API path from `/references` to `/symbol/find-references`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-5801e0b4b6989cc391ff85a9cd2ef435acb83e1cb9d0852fca84f21786472c3d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace_files.rs</strong><dd><code>Update API path for listing workspace files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/workspace_files.rs
<li>Updated API path from <code>/workspace-files</code> to <code>/workspace/list-files</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-49becda8af25f045242a3639b0091ea825596f2275074f7a492a2c0504308930">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Reorganize API service scopes and paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lib.rs
- Reorganized API service scopes and updated paths.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-53708e4140a781f3947933d6e52e5b632e2601fd242c72f3ef8812284fe43b53">+10/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.json</strong><dd><code>Update OpenAPI documentation with new API paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi.json
<li>Updated API paths to reflect new endpoint structure.<br> <li> Adjusted documentation for new paths.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/48/files#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713">+41/-41</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details><summary><strong>🔍 Infra Scan Results:</strong></summary><hr>
<table><tr><td><details><summary><strong>Failed Openapi Checks</strong></summary><div><table><tr><th>Check Name</th><th>File Path</th><th>Lines</th></tr><tr><td>Ensure that the global security field has rules defined</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/57b176dab40cd8dfb96ba8afc0a971320c6481f6/openapi.json#L1:L449' target='_blank'>1-449</a></td></tr><tr><td>Ensure that security operations is not empty.</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/57b176dab40cd8dfb96ba8afc0a971320c6481f6/openapi.json#L1:L449' target='_blank'>1-449</a></td></tr><tr><td>Ensure that arrays have a maximum number of items</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/57b176dab40cd8dfb96ba8afc0a971320c6481f6/openapi.json#L155:L160' target='_blank'>155-160</a></td></tr></table></div></details></td></tr></table></details><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
