### PR TITLE
Switch to jedi, remove declaration option

### DIFF
--- a/lsproxy/Dockerfile
+++ b/lsproxy/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python3 \
     python3-pip \
+    python3-venv \
     curl \
     && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \
@@ -22,8 +23,15 @@ RUN apt-get update && apt-get install -y \
 RUN rustup component add rust-analyzer
 RUN rustup component add rustfmt
 
+# Angrily create a virtual environment
+RUN python3 -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+
+# Install pylsp
+RUN pip install jedi-language-server
+
 # Install global npm packages
-RUN npm install -g pyright typescript-language-server typescript
+RUN npm install -g typescript-language-server typescript
 
 RUN cargo install cargo-llvm-cov
 RUN rustup component add llvm-tools-preview

--- a/lsproxy/src/api_types.rs
+++ b/lsproxy/src/api_types.rs
@@ -163,11 +163,6 @@ pub struct GetDefinitionRequest {
 pub struct GetReferencesRequest {
     pub identifier_position: FilePosition,
 
-    /// Whether to include the declaration (definition) of the symbol in the response.
-    /// Defaults to false.
-    #[serde(default)]
-    pub include_declaration: bool,
-
     /// Whether to include the source code of the symbol in the response.
     /// Defaults to none.
     #[serde(default)]

--- a/lsproxy/src/handlers/find_references.rs
+++ b/lsproxy/src/handlers/find_references.rs
@@ -58,7 +58,6 @@ pub async fn find_references(
                 line: info.identifier_position.position.line,
                 character: info.identifier_position.position.character,
             },
-            info.include_declaration,
         )
         .await;
 
@@ -216,7 +215,6 @@ mod test {
                     character: 6,
                 },
             },
-            include_declaration: false,
             include_code_context_lines: None,
             include_raw_response: false,
         });
@@ -237,6 +235,13 @@ mod test {
         let expected_response = ReferencesResponse {
             raw_response: None,
             references: vec![
+                FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 0,
+                        character: 6,
+                    },
+                },
                 FilePosition {
                     path: String::from("main.py"),
                     position: Position {
@@ -272,7 +277,6 @@ mod test {
                     character: 11,
                 },
             },
-            include_declaration: false,
             include_code_context_lines: None,
             include_raw_response: false,
         });
@@ -335,6 +339,13 @@ mod test {
                     position: Position {
                         line: 93,
                         character: 23,
+                    },
+                },
+                FilePosition {
+                    path: String::from("src/node.rs"),
+                    position: Position {
+                        line: 3,
+                        character: 11,
                     },
                 },
                 FilePosition {

--- a/lsproxy/src/lsp/client.rs
+++ b/lsproxy/src/lsp/client.rs
@@ -281,8 +281,10 @@ pub trait LspClient: Send {
         &mut self,
         file_path: &str,
         position: Position,
-        include_declaration: bool,
     ) -> Result<Vec<Location>, Box<dyn Error + Send + Sync>> {
+        // TODO: the jedi language server doesn't appear to respect
+        // The "includeDeclaration" param so we'll just say we're
+        // always including it
         let params = ReferenceParams {
             text_document_position: TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
@@ -293,7 +295,7 @@ pub trait LspClient: Send {
             work_done_progress_params: WorkDoneProgressParams::default(),
             partial_result_params: PartialResultParams::default(),
             context: ReferenceContext {
-                include_declaration,
+                include_declaration: true
             },
         };
 

--- a/lsproxy/src/lsp/languages/python.rs
+++ b/lsproxy/src/lsp/languages/python.rs
@@ -46,8 +46,7 @@ impl PyrightClient {
         root_path: &str,
         watch_events_rx: Receiver<DebouncedEvent>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let process = Command::new("pyright-langserver")
-            .arg("--stdio")
+        let process = Command::new("jedi-language-server")
             .current_dir(root_path)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/lsproxy/src/lsp/manager.rs
+++ b/lsproxy/src/lsp/manager.rs
@@ -225,7 +225,6 @@ impl Manager {
         &self,
         file_path: &str,
         position: Position,
-        include_declaration: bool,
     ) -> Result<Vec<Location>, LspManagerError> {
         let workspace_files = self.list_files().await.map_err(|e| {
             LspManagerError::InternalError(format!("Workspace file retrieval failed: {}", e))
@@ -246,7 +245,7 @@ impl Manager {
         let mut locked_client = client.lock().await;
 
         locked_client
-            .text_document_reference(full_path_str, position, include_declaration)
+            .text_document_reference(full_path_str, position)
             .await
             .map_err(|e| {
                 LspManagerError::InternalError(format!("Reference retrieval failed: {}", e))
@@ -462,11 +461,23 @@ mod tests {
                     line: 0,
                     character: 6,
                 },
-                false,
             )
             .await?;
 
         let expected = vec![
+            Location {
+                uri: Url::parse("file:///mnt/lsproxy_root/sample_project/python/graph.py").unwrap(),
+                range: Range {
+                    start: lsp_types::Position {
+                        line: 0,
+                        character: 6,
+                    },
+                    end: lsp_types::Position {
+                        line: 0,
+                        character: 16,
+                    },
+                },
+            },
             Location {
                 uri: Url::parse("file:///mnt/lsproxy_root/sample_project/python/main.py").unwrap(),
                 range: Range {
@@ -685,13 +696,25 @@ mod tests {
                 file_path,
                 lsp_types::Position {
                     line: 0,
-                    character: 6,
+                    character: 9,
                 },
-                false,
             )
             .await?;
 
         let expected = vec![
+            Location {
+                uri: Url::parse("file:///mnt/lsproxy_root/sample_project/js/astar_search.js")?,
+                range: Range {
+                    start: lsp_types::Position {
+                        line: 0,
+                        character: 9,
+                    },
+                    end: lsp_types::Position {
+                        line: 0,
+                        character: 18,
+                    },
+                },
+            },
             Location {
                 uri: Url::parse("file:///mnt/lsproxy_root/sample_project/js/astar_search.js")?,
                 range: Range {
@@ -807,7 +830,6 @@ mod tests {
                     line: 3,
                     character: 11,
                 },
-                false,
             )
             .await?;
 
@@ -821,6 +843,19 @@ mod tests {
             })
         });
         let mut expected = vec![
+            Location {
+                uri: Url::parse("file:///mnt/lsproxy_root/sample_project/rust/src/node.rs")?,
+                range: Range {
+                    start: lsp_types::Position {
+                        line: 3,
+                        character: 11,
+                    },
+                    end: lsp_types::Position {
+                        line: 3,
+                        character: 15,
+                    },
+                },
+            },
             Location {
                 uri: Url::parse("file:///mnt/lsproxy_root/sample_project/rust/src/node.rs")?,
                 range: Range {

--- a/openapi.json
+++ b/openapi.json
@@ -354,10 +354,6 @@
             "example": 5,
             "minimum": 0
           },
-          "include_declaration": {
-            "type": "boolean",
-            "description": "Whether to include the declaration (definition) of the symbol in the response.\nDefaults to false."
-          },
           "include_raw_response": {
             "type": "boolean",
             "description": "Whether to include the raw response from the langserver in the response.\nDefaults to false.",

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
     git \
     python3 \
     python3-pip \
+    python3-venv \
     curl \
     && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \
@@ -27,8 +28,15 @@ RUN apt-get update && apt-get install -y \
 # Add rust-analyzer
 RUN rustup component add rust-analyzer
 
+# Angrily create a virtual environment
+RUN python3 -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+
+# Install pylsp
+RUN pip install jedi-language-server
+
 # Install language servers
-RUN npm install -g pyright typescript-language-server typescript
+RUN npm install -g typescript-language-server typescript
 
 # Install ast grep
 RUN cargo install ast-grep --locked


### PR DESCRIPTION
## **Description**
- Removed the `include_declaration` parameter from various components, including API types, handlers, and LSP manager.
- Switched the Python language server from `pyright-langserver` to `jedi-language-server`.
- Updated Dockerfiles to install `jedi-language-server` in a Python virtual environment and removed `pyright`.
- Updated test cases to reflect changes in the handling of the `include_declaration` parameter.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api_types.rs</strong><dd><code>Remove `include_declaration` field from API types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/api_types.rs
<li>Removed the <code>include_declaration</code> field from <code>GetReferencesRequest</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-18c0dbf0ba09194cd0719ebd4862de79ce4d68e67f81dac5142d4dfcf12d2085">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>find_references.rs</strong><dd><code>Update handlers to remove `include_declaration` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/find_references.rs
<li>Removed the <code>include_declaration</code> parameter from function calls.<br> <li> Updated test cases to reflect the removal of <code>include_declaration</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-2928da39d39611f0c251df367f94bb73421a526d528b3e68fa9f0b5324bc7b6f">+14/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Modify LSP client to always include declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/client.rs
<li>Removed <code>include_declaration</code> parameter from <code>text_document_reference</code>.<br> <li> Added a comment regarding the behavior of the Jedi language server.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-36b320cabc75844e87dcec1ab0abfa27a3f1af02c987a99a756413197d8d7bb9">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>python.rs</strong><dd><code>Switch Python LSP client to Jedi language server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/python.rs
- Switched from `pyright-langserver` to `jedi-language-server`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-f8dd4e1feb6379800abf5642dfb74b49bba91cc266617f62d4fe16b155be253b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager.rs</strong><dd><code>Update LSP manager to remove `include_declaration` parameter</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/manager.rs
<li>Removed <code>include_declaration</code> parameter from <code>find_references</code>.<br> <li> Updated test cases to reflect the removal of <code>include_declaration</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-932f8e768420458f1d9090b5b74386a75a75ca9ee0a94b40e525d2b9cb858a38">+41/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>openapi.json</strong><dd><code>Remove `include_declaration` from OpenAPI schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi.json
- Removed `include_declaration` field from the API schema.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile to use Jedi and virtual environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/Dockerfile
<li>Added <code>python3-venv</code> to the installation.<br> <li> Installed <code>jedi-language-server</code> in a virtual environment.<br> <li> Removed <code>pyright</code> from npm global packages.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-1212077c4e3bc5a35b9c09d0ce0a5e7b9a3e49361ca461f780ee76d21908807b">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update release Dockerfile to use Jedi and virtual environment</code>&nbsp; &nbsp; </dd></summary>
<hr>

release/Dockerfile
<li>Added <code>python3-venv</code> to the installation.<br> <li> Installed <code>jedi-language-server</code> in a virtual environment.<br> <li> Removed <code>pyright</code> from npm global packages.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/65/files#diff-6c918453ca10323eddc8ae7806dbc52208171ff61d7dadf48fb3586d750e085d">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details><summary><strong>🔍 Infra Scan Results:</strong></summary><hr>
<table><tr><td><details><summary><strong>Failed Dockerfile Checks</strong></summary><div><table><tr><th>Check Name</th><th>File Path</th><th>Lines</th></tr><tr><td>Ensure that HEALTHCHECK instructions have been added to container images</td><td>lsproxy/Dockerfile</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/lsproxy/Dockerfile#L1:L59' target='_blank'>1-59</a></td></tr><tr><td>Ensure that a user for the container has been created</td><td>lsproxy/Dockerfile</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/lsproxy/Dockerfile#L1:L59' target='_blank'>1-59</a></td></tr><tr><td>Ensure that HEALTHCHECK instructions have been added to container images</td><td>release/Dockerfile</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/release/Dockerfile#L1:L54' target='_blank'>1-54</a></td></tr><tr><td>Ensure that a user for the container has been created</td><td>release/Dockerfile</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/release/Dockerfile#L1:L54' target='_blank'>1-54</a></td></tr></table></div></details></td></tr><tr><td><details><summary><strong>Failed Openapi Checks</strong></summary><div><table><tr><th>Check Name</th><th>File Path</th><th>Lines</th></tr><tr><td>Ensure that the global security field has rules defined</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/openapi.json#L1:L502' target='_blank'>1-502</a></td></tr><tr><td>Ensure that security operations is not empty.</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/openapi.json#L1:L502' target='_blank'>1-502</a></td></tr><tr><td>Ensure that arrays have a maximum number of items</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3173edb4f523f427ca9e45922cb1418c1cebe755/openapi.json#L43:L48' target='_blank'>43-48</a></td></tr></table></div></details></td></tr></table></details><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
