### PR TITLE
include decorators in function defs

### DIFF
--- a/lsproxy/src/ast_grep/rules/python/function.yml
+++ b/lsproxy/src/ast_grep/rules/python/function.yml
@@ -1,6 +1,22 @@
 id: function
-language: python
-rule:
+utils:
+  is_funcdef:
     kind: identifier
     inside:
       kind: function_definition
+# this rule is written a little weirdly
+# it matches an identifier inside function_definition
+# but also matches an identifier inside decorated_definition 
+# returning the range with the decorator as the outer node so the range includes the decorator
+language: python
+rule:
+    any:
+      - matches: is_funcdef
+      - inside:
+          kind: decorated_definition
+          stopBy:
+            kind: function_definition
+        matches: is_funcdef
+
+
+

--- a/lsproxy/src/ast_grep/rules/python/function.yml
+++ b/lsproxy/src/ast_grep/rules/python/function.yml
@@ -5,6 +5,9 @@ utils:
     inside:
       kind: function_definition
 
+# this rule is written a little weirdly
+# in both cases we want to match an identifier inside a function definition
+# but in the second case we want to return the range of the decorator as the outer node
 language: python
 rule:
     any:

--- a/lsproxy/src/ast_grep/rules/python/function.yml
+++ b/lsproxy/src/ast_grep/rules/python/function.yml
@@ -4,19 +4,12 @@ utils:
     kind: identifier
     inside:
       kind: function_definition
-# this rule is written a little weirdly
-# it matches an identifier inside function_definition
-# but also matches an identifier inside decorated_definition 
-# returning the range with the decorator as the outer node so the range includes the decorator
+
 language: python
 rule:
     any:
-      - matches: is_funcdef
       - inside:
           kind: decorated_definition
-          stopBy:
-            kind: function_definition
+          stopBy: end
         matches: is_funcdef
-
-
-
+      - matches: is_funcdef


### PR DESCRIPTION
## **Description**
- Introduced a utility function `is_funcdef` to identify function definitions.
- Enhanced the function rule to include decorators in the definition range.
- Modified the rule to match identifiers inside both `function_definition` and `decorated_definition`.
- Ensured the range includes decorators by matching `decorated_definition`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function.yml</strong><dd><code>Enhance function rule to include decorators in definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/ast_grep/rules/python/function.yml
<li>Introduced a utility function <code>is_funcdef</code> to identify function <br>definitions.<br> <li> Enhanced the rule to include decorators in the function definition <br>range.<br> <li> Modified the rule to match identifiers inside both <code>function_definition</code> <br>and <code>decorated_definition</code>.<br> <li> Ensured the range includes decorators by matching <br><code>decorated_definition</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/69/files#diff-70d835c421b4f30fa7a08771569a7339dc4034af467ac137ef7de8c65312637b">+14/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
