### PR TITLE
Rename

### DIFF
--- a/lsproxy/src/api_types.rs
+++ b/lsproxy/src/api_types.rs
@@ -287,9 +287,13 @@ pub struct TextEdit {
 
 impl From<WorkspaceEdit> for RenameResponse {
     fn from(edit: WorkspaceEdit) -> Self {
-        let changes = edit
-            .changes
-            .unwrap_or_default()
+        let changes = match edit.changes {
+            Some(changes) => changes,
+            None => {
+                warn!("No changes found in WorkspaceEdit");
+                return RenameResponse { changes: HashMap::new() };
+            }
+        };
             .into_iter()
             .map(|(uri, edits)| {
                 let path = uri_to_relative_path_string(&uri);

--- a/lsproxy/src/ast_grep/rules/c/function.yml
+++ b/lsproxy/src/ast_grep/rules/c/function.yml
@@ -4,4 +4,4 @@ rule:
   kind: identifier
   inside:
     kind: function_declarator
-    name: declarator
+    field: declarator

--- a/lsproxy/src/handlers/mod.rs
+++ b/lsproxy/src/handlers/mod.rs
@@ -3,7 +3,8 @@ mod find_definition;
 mod find_references;
 mod list_files;
 mod read_source_code;
+mod rename;
 pub use self::{
     definitions_in_file::*, find_definition::*, find_references::*, list_files::*,
-    read_source_code::*,
+    read_source_code::*, rename::*,
 };

--- a/lsproxy/src/handlers/rename.rs
+++ b/lsproxy/src/handlers/rename.rs
@@ -29,7 +29,11 @@ pub async fn rename(data: Data<AppState>, info: Json<RenameRequest>) -> HttpResp
                 error: format!("Failed to lock manager: {}", e),
             })
         })
-        .unwrap();
+        .unwrap_or_else(|_| {
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: "Failed to acquire manager lock".to_string(),
+            });
+        });
 
     let result = manager
         .rename_symbol(

--- a/lsproxy/src/handlers/rename.rs
+++ b/lsproxy/src/handlers/rename.rs
@@ -1,0 +1,50 @@
+use actix_web::{
+    web::{Data, Json},
+    HttpResponse,
+};
+use lsp_types::Position as LspPosition;
+
+use crate::{
+    api_types::{ErrorResponse, RenameRequest, RenameResponse},
+    AppState,
+};
+
+#[utoipa::path(
+    post,
+    path = "/symbol/rename",
+    tag = "symbol",
+    request_body = RenameRequest,
+    responses(
+        (status = 200, description = "Symbol renamed successfully", body = RenameResponse),
+        (status = 400, description = "Bad request"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn rename(data: Data<AppState>, info: Json<RenameRequest>) -> HttpResponse {
+    let manager = data
+        .manager
+        .lock()
+        .map_err(|e| {
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to lock manager: {}", e),
+            })
+        })
+        .unwrap();
+
+    let result = manager
+        .rename_symbol(
+            &info.position.path,
+            LspPosition {
+                line: info.position.position.line,
+                character: info.position.position.character,
+            },
+            info.new_name.clone(),
+        )
+        .await;
+    match result {
+        Ok(edit) => HttpResponse::Ok().json(RenameResponse::from(edit)),
+        Err(e) => HttpResponse::InternalServerError().json(ErrorResponse {
+            error: format!("Failed to rename symbol: {}", e),
+        }),
+    }
+}

--- a/lsproxy/src/handlers/rename.rs
+++ b/lsproxy/src/handlers/rename.rs
@@ -21,19 +21,14 @@ use crate::{
     )
 )]
 pub async fn rename(data: Data<AppState>, info: Json<RenameRequest>) -> HttpResponse {
-    let manager = data
-        .manager
-        .lock()
-        .map_err(|e| {
-            HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to lock manager: {}", e),
-            })
-        })
-        .unwrap_or_else(|_| {
+    let manager = match data.manager.lock() {
+        Ok(manager) => manager,
+        Err(e) => {
             return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: "Failed to acquire manager lock".to_string(),
+                error: format!("Failed to lock manager: {}", e),
             });
-        });
+        }
+    };
 
     let result = manager
         .rename_symbol(

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -112,8 +112,10 @@ pub async fn initialize_app_state_with_mount_dir(
 
     let host = env::var("LSPROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port = env::var("LSPROXY_PORT")
-        .ok()
-        .and_then(|p| p.parse::<u16>().ok())
+        .and_then(|p| p.parse::<u16>().map_err(|_| {
+            warn!("Invalid port number in LSPROXY_PORT, using default 4444");
+            4444
+        }).ok())
         .unwrap_or(4444);
 
     let app_state = Data::new(AppState { manager });

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -8,7 +8,6 @@ use api_types::{
 };
 use handlers::{read_source_code, rename};
 use log::warn;
-use std::env;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -110,21 +109,7 @@ pub async fn initialize_app_state_with_mount_dir(
         .start_langservers(&mount_dir)
         .await?;
 
-    let host = env::var("LSPROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let port = env::var("LSPROXY_PORT")
-        .ok()
-        .and_then(|p| {
-            p.parse::<u16>()
-                .map_err(|_| {
-                    warn!("Invalid port number in LSPROXY_PORT, using default 4444");
-                })
-                .ok()
-        })
-        .unwrap_or(4444);
-
-    let app_state = Data::new(AppState { manager });
-    run_server_with_port_and_host(app_state.clone(), port, &host).await?;
-    Ok(app_state)
+    Ok(Data::new(AppState { manager }))
 }
 
 // Helper enum for cleaner matching

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -113,9 +113,13 @@ pub async fn initialize_app_state_with_mount_dir(
     let host = env::var("LSPROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port = env::var("LSPROXY_PORT")
         .ok()
-        .and_then(|p| p.parse::<u16>().map_err(|_| {
-            warn!("Invalid port number in LSPROXY_PORT, using default 4444");
-        }).ok())
+        .and_then(|p| {
+            p.parse::<u16>()
+                .map_err(|_| {
+                    warn!("Invalid port number in LSPROXY_PORT, using default 4444");
+                })
+                .ok()
+        })
         .unwrap_or(4444);
 
     let app_state = Data::new(AppState { manager });

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -341,8 +341,8 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn test_run_server() -> Result<(), Box<dyn std::error::Error>> {
+    #[tokio::test]
+    async fn test_run_server() -> Result<(), Box<dyn std::error::Error>> {
         let test_path = js_sample_path();
         let (tx, rx) = mpsc::channel();
 

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -112,9 +112,9 @@ pub async fn initialize_app_state_with_mount_dir(
 
     let host = env::var("LSPROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port = env::var("LSPROXY_PORT")
+        .ok()
         .and_then(|p| p.parse::<u16>().map_err(|_| {
             warn!("Invalid port number in LSPROXY_PORT, using default 4444");
-            4444
         }).ok())
         .unwrap_or(4444);
 

--- a/lsproxy/src/lsp/client.rs
+++ b/lsproxy/src/lsp/client.rs
@@ -447,7 +447,9 @@ pub trait LspClient: Send {
         let params = RenameParams {
             text_document_position: TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(file_path).unwrap(),
+                    uri: Url::from_file_path(file_path).unwrap_or_else(|_| {
+                        panic!("Invalid file path: {}", file_path);
+                    }),
                 },
                 position,
             },

--- a/lsproxy/src/lsp/languages/java.rs
+++ b/lsproxy/src/lsp/languages/java.rs
@@ -65,7 +65,7 @@ impl LspClient for JdtlsClient {
                 message: "ServiceReady".to_string(),
             })
             .await?;
-        debug!("Java: waiting for service ready notification.This may take a minute...");
+        debug!("Java: waiting for service ready notification. This may take a minute...");
         tokio::time::timeout(std::time::Duration::from_secs(180), notification_rx.recv()).await??;
         Ok(init_result)
     }

--- a/lsproxy/src/lsp/manager.rs
+++ b/lsproxy/src/lsp/manager.rs
@@ -334,8 +334,15 @@ impl Manager {
         position: Position,
         new_name: String,
     ) -> Result<WorkspaceEdit, LspManagerError> {
-        let client = self.get_client(self.detect_language(file_path)?).ok_or(
-            LspManagerError::LspClientNotFound(self.detect_language(file_path)?),
+        let detected_language = self.detect_language(file_path)?;
+        if detected_language != SupportedLanguages::Java {
+            return Err(LspManagerError::UnsupportedFileType(format!(
+                "Renames are only supported for Java, got: {:?}",
+                detected_language
+            )));
+        }
+        let client = self.get_client(detected_language).ok_or(
+            LspManagerError::LspClientNotFound(detected_language),
         )?;
         let mut locked_client = client.lock().await;
         let full_path = get_mount_dir().join(&file_path);

--- a/lsproxy/src/lsp/manager.rs
+++ b/lsproxy/src/lsp/manager.rs
@@ -341,9 +341,9 @@ impl Manager {
                 detected_language
             )));
         }
-        let client = self.get_client(detected_language).ok_or(
-            LspManagerError::LspClientNotFound(detected_language),
-        )?;
+        let client = self
+            .get_client(detected_language)
+            .ok_or(LspManagerError::LspClientNotFound(detected_language))?;
         let mut locked_client = client.lock().await;
         let full_path = get_mount_dir().join(&file_path);
         let full_path_str = full_path.to_str().unwrap_or_default();

--- a/lsproxy/src/lsp/manager.rs
+++ b/lsproxy/src/lsp/manager.rs
@@ -11,9 +11,7 @@ use crate::utils::workspace_documents::{
     PYTHON_FILE_PATTERNS, RUST_ANALYZER_FILE_PATTERNS, TYPESCRIPT_FILE_PATTERNS,
 };
 use log::{debug, error, warn};
-use lsp_types::{
-    DocumentSymbolResponse, GotoDefinitionResponse, Location, Position, Range, WorkspaceEdit,
-};
+use lsp_types::{GotoDefinitionResponse, Location, Position, Range, WorkspaceEdit};
 use notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult, DebouncedEvent};
 use std::collections::HashMap;
@@ -167,29 +165,6 @@ impl Manager {
             self.lsp_clients.insert(lsp, Arc::new(Mutex::new(client)));
         }
         Ok(())
-    }
-
-    #[deprecated(note = "Use definitions_in_file_ast_grep instead")]
-    pub async fn definitions_in_file(
-        &self,
-        file_path: &str,
-    ) -> Result<DocumentSymbolResponse, LspManagerError> {
-        // Check if the file_path is included in the workspace files
-        let workspace_files = self.list_files().await?;
-        if !workspace_files.iter().any(|f| f == file_path) {
-            return Err(LspManagerError::FileNotFound(file_path.to_string()));
-        }
-        let full_path = get_mount_dir().join(&file_path);
-        let full_path_str = full_path.to_str().unwrap_or_default();
-        let lsp_type = self.detect_language(full_path_str)?;
-        let client = self
-            .get_client(lsp_type)
-            .ok_or(LspManagerError::LspClientNotFound(lsp_type))?;
-        let mut locked_client = client.lock().await;
-        locked_client
-            .text_document_symbols(full_path_str)
-            .await
-            .map_err(|e| LspManagerError::InternalError(format!("Symbol retrieval failed: {}", e)))
     }
 
     pub async fn definitions_in_file_ast_grep(

--- a/openapi.json
+++ b/openapi.json
@@ -134,6 +134,42 @@
         }
       }
     },
+    "/symbol/rename": {
+      "post": {
+        "tags": [
+          "symbol"
+        ],
+        "operationId": "rename",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Symbol renamed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RenameResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/workspace/list-files": {
       "get": {
         "tags": [
@@ -423,6 +459,41 @@
           }
         }
       },
+      "RenameRequest": {
+        "type": "object",
+        "required": [
+          "position",
+          "new_name"
+        ],
+        "properties": {
+          "new_name": {
+            "type": "string"
+          },
+          "position": {
+            "$ref": "#/components/schemas/FilePosition"
+          }
+        }
+      },
+      "RenameResponse": {
+        "type": "object",
+        "required": [
+          "changes"
+        ],
+        "properties": {
+          "changes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/TextEdit"
+              }
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "SupportedLanguages": {
         "type": "string",
         "enum": [
@@ -459,6 +530,21 @@
           "range": {
             "$ref": "#/components/schemas/FileRange",
             "description": "The full range of the symbol."
+          }
+        }
+      },
+      "TextEdit": {
+        "type": "object",
+        "required": [
+          "range",
+          "new_text"
+        ],
+        "properties": {
+          "new_text": {
+            "type": "string"
+          },
+          "range": {
+            "$ref": "#/components/schemas/FileRange"
           }
         }
       },

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,4 +9,8 @@ PORT=${2:-4444}
 ./scripts/build.sh
 
 # Run the application
+if [ -z "$1" ] || [ ! -d "$1" ]; then
+    echo "Error: Please provide a valid directory as the first argument."
+    exit 1
+fi
 docker run --rm -p ${PORT}:4444 -v $1:/mnt/workspace -v "$(pwd)/lsproxy/target/release":/usr/src/app lsproxy-dev ./lsproxy

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,4 @@ PORT=${2:-4444}
 ./scripts/build.sh
 
 # Run the application
-if [ -z "$1" ] || [ ! -d "$1" ]; then
-    echo "Error: Please provide a valid directory as the first argument."
-    exit 1
-fi
 docker run --rm -p ${PORT}:4444 -v $1:/mnt/workspace -v "$(pwd)/lsproxy/target/release":/usr/src/app lsproxy-dev ./lsproxy

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,8 +2,11 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
+# Default port if not specified
+PORT=${2:-4444}
+
 # Run the build
 ./scripts/build.sh
 
 # Run the application
-docker run --rm -p 4444:4444 -v $1:/mnt/workspace -v "$(pwd)/lsproxy/target/release":/usr/src/app lsproxy-dev ./lsproxy
+docker run --rm -p ${PORT}:4444 -v $1:/mnt/workspace -v "$(pwd)/lsproxy/target/release":/usr/src/app lsproxy-dev ./lsproxy

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -e  # Exit immediately if a command exits with a non-zero status
 # Build the application using the build Dockerfile
 docker build -t lsproxy-dev lsproxy
 
-if ! docker run --rm -v "$(pwd)/lsproxy":/usr/src/app -v "$(pwd)":/mnt/lsproxy_root lsproxy-dev cargo test --lib --bins --tests; then
+if ! docker run --rm -v "$(pwd)/lsproxy":/usr/src/app -v "$(pwd)":/mnt/lsproxy_root lsproxy-dev cargo test --lib --bins --tests -- --nocapture; then
     echo "Tests failed. Exiting."
     exit 1
 fi


### PR DESCRIPTION
## **Description**
- Introduced new structs `RenameRequest`, `RenameResponse`, and `TextEdit` for handling rename operations.
- Implemented a new handler for renaming symbols with HTTP response handling and error management.
- Added methods in the LSP client for executing rename commands.
- Integrated rename functionality into the main application and added configuration for host and port.
- Updated run script to support port configuration via environment variable.
- Added API endpoint for renaming symbols and defined request and response schemas in the OpenAPI specification.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_types.rs</strong><dd><code>Add structs and conversion logic for rename operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/api_types.rs
<li>Added new structs <code>RenameRequest</code>, <code>RenameResponse</code>, and <code>TextEdit</code> for <br>rename operations.<br> <li> Implemented conversion logic from <code>WorkspaceEdit</code> to <code>RenameResponse</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-18c0dbf0ba09194cd0719ebd4862de79ce4d68e67f81dac5142d4dfcf12d2085">+52/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Integrate rename module into handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/mod.rs
- Integrated the rename module into handlers.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-b252c8466729a343d9086994dce0abfee45d35d9c2638a8a81c162c32ef70189">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rename.rs</strong><dd><code>Implement rename handler with HTTP response management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/rename.rs
<li>Implemented a new handler for renaming symbols.<br> <li> Added HTTP response handling and error management.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-43e7bd2ef0adb4bff8b951df74f47ca79e2ca94aef91fd8d8df0d602ad190ad5">+49/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Integrate rename handler and update OpenAPI components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lib.rs
<li>Added rename handler to the server setup.<br> <li> Updated OpenAPI components with rename-related schemas.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-53708e4140a781f3947933d6e52e5b632e2601fd242c72f3ef8812284fe43b53">+12/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Add rename method to LSP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/client.rs
- Added `text_document_rename` method to the LSP client.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-36b320cabc75844e87dcec1ab0abfa27a3f1af02c987a99a756413197d8d7bb9">+30/-30</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager.rs</strong><dd><code>Add rename symbol method with Java restriction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/manager.rs
<li>Added <code>rename_symbol</code> method to the manager for handling rename <br>operations.<br> <li> Restricted rename functionality to Java files.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-932f8e768420458f1d9090b5b74386a75a75ca9ee0a94b40e525d2b9cb858a38">+27/-24</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test.sh</strong><dd><code>Enhance test script output visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test.sh
<li>Modified test script to include <code>--nocapture</code> for better test output <br>visibility.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>run.sh</strong><dd><code>Support port configuration in run script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/run.sh
- Added support for port configuration via environment variable.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-bb563bfe483a3a9b1649cf50d2246475b9565947f5226b94fa0d72c9786ab298">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.json</strong><dd><code>Add rename endpoint and schemas to OpenAPI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi.json
<li>Added API endpoint for renaming symbols.<br> <li> Defined request and response schemas for rename operations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/71/files#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713">+86/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
