### PR TITLE
Add python extensions and fix decorator bug

### DIFF
--- a/lsproxy/src/ast_grep/rules/python/function.yml
+++ b/lsproxy/src/ast_grep/rules/python/function.yml
@@ -14,5 +14,8 @@ rule:
       - inside:
           kind: decorated_definition
           stopBy: end
+          has:
+            kind:
+              function_definition
         matches: is_funcdef
       - matches: is_funcdef

--- a/lsproxy/src/handlers/definitions_in_file.rs
+++ b/lsproxy/src/handlers/definitions_in_file.rs
@@ -36,7 +36,10 @@ pub async fn definitions_in_file(
     data: Data<AppState>,
     info: Query<FileSymbolsRequest>,
 ) -> HttpResponse {
-    info!("Received get_symbols request for file: {}", info.file_path);
+    info!(
+        "Received definitions in file request for file: {}",
+        info.file_path
+    );
     let manager = match data.manager.lock() {
         Ok(guard) => guard,
         Err(e) => {

--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -191,7 +191,7 @@ mod test {
             definitions: vec![FilePosition {
                 path: String::from("graph.py"),
                 position: Position {
-                    line: 0,
+                    line: 1,
                     character: 6,
                 },
             }],

--- a/lsproxy/src/handlers/find_references.rs
+++ b/lsproxy/src/handlers/find_references.rs
@@ -211,7 +211,7 @@ mod test {
             identifier_position: FilePosition {
                 path: String::from("graph.py"),
                 position: Position {
-                    line: 0,
+                    line: 1,
                     character: 6,
                 },
             },
@@ -238,7 +238,7 @@ mod test {
                 FilePosition {
                     path: String::from("graph.py"),
                     position: Position {
-                        line: 0,
+                        line: 1,
                         character: 6,
                     },
                 },

--- a/lsproxy/src/lsp/languages/rust.rs
+++ b/lsproxy/src/lsp/languages/rust.rs
@@ -13,8 +13,7 @@ use tokio::sync::broadcast::Receiver;
 use crate::lsp::{JsonRpcHandler, LspClient, PendingRequests, ProcessHandler};
 
 use crate::utils::workspace_documents::{
-    WorkspaceDocumentsHandler, DEFAULT_EXCLUDE_PATTERNS, RUST_ANALYZER_FILE_PATTERNS,
-    RUST_ANALYZER_ROOT_FILES,
+    WorkspaceDocumentsHandler, DEFAULT_EXCLUDE_PATTERNS, RUST_FILE_PATTERNS, RUST_ROOT_FILES,
 };
 
 pub struct RustAnalyzerClient {
@@ -81,10 +80,7 @@ impl LspClient for RustAnalyzerClient {
     }
 
     fn get_root_files(&mut self) -> Vec<String> {
-        RUST_ANALYZER_ROOT_FILES
-            .iter()
-            .map(|&s| s.to_owned())
-            .collect()
+        RUST_ROOT_FILES.iter().map(|&s| s.to_owned()).collect()
     }
 
     fn get_workspace_documents(&mut self) -> &mut WorkspaceDocumentsHandler {
@@ -126,10 +122,7 @@ impl RustAnalyzerClient {
 
         let workspace_documents = WorkspaceDocumentsHandler::new(
             Path::new(root_path),
-            RUST_ANALYZER_FILE_PATTERNS
-                .iter()
-                .map(|&s| s.to_string())
-                .collect(),
+            RUST_FILE_PATTERNS.iter().map(|&s| s.to_string()).collect(),
             DEFAULT_EXCLUDE_PATTERNS
                 .iter()
                 .map(|&s| s.to_string())

--- a/lsproxy/src/lsp/manager.rs
+++ b/lsproxy/src/lsp/manager.rs
@@ -478,6 +478,158 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_file_symbols_python_decorators() -> Result<(), Box<dyn std::error::Error>> {
+        let context = TestContext::setup(&python_sample_path(), true).await?;
+        let manager = context
+            .manager
+            .as_ref()
+            .ok_or("Manager is not initialized")?;
+
+        let file_path = "graph.py";
+        let file_symbols = manager.definitions_in_file_ast_grep(file_path).await?;
+
+        let symbol_response: SymbolResponse =
+            file_symbols.into_iter().map(|s| Symbol::from(s)).collect();
+
+        let expected = vec![
+            Symbol {
+                name: String::from("AStarGraph"),
+                kind: String::from("class"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 1,
+                        character: 6,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 1,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 60,
+                        character: 40,
+                    },
+                },
+            },
+            Symbol {
+                name: String::from("__init__"),
+                kind: String::from("function"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 4,
+                        character: 8,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 21,
+                        character: 9,
+                    },
+                },
+            },
+            Symbol {
+                name: String::from("barriers"),
+                kind: String::from("function"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 24,
+                        character: 8,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 23,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 25,
+                        character: 28,
+                    },
+                },
+            },
+            Symbol {
+                name: String::from("heuristic"),
+                kind: String::from("function"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 27,
+                        character: 8,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 27,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 34,
+                        character: 57,
+                    },
+                },
+            },
+            Symbol {
+                name: String::from("get_vertex_neighbours"),
+                kind: String::from("function"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 36,
+                        character: 8,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 36,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 54,
+                        character: 16,
+                    },
+                },
+            },
+            Symbol {
+                name: String::from("move_cost"),
+                kind: String::from("function"),
+                identifier_position: FilePosition {
+                    path: String::from("graph.py"),
+                    position: Position {
+                        line: 56,
+                        character: 8,
+                    },
+                },
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    start: Position {
+                        line: 56,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 60,
+                        character: 40,
+                    },
+                },
+            },
+        ];
+        assert_eq!(symbol_response, expected);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_file_symbols_cpp() -> Result<(), Box<dyn std::error::Error>> {
         let context = TestContext::setup(&cpp_sample_path(), true).await?;
         let manager = context
@@ -757,7 +909,7 @@ mod tests {
             .find_references(
                 file_path,
                 lsp_types::Position {
-                    line: 0,
+                    line: 1,
                     character: 6,
                 },
             )
@@ -768,11 +920,11 @@ mod tests {
                 uri: Url::parse("file:///mnt/lsproxy_root/sample_project/python/graph.py").unwrap(),
                 range: Range {
                     start: lsp_types::Position {
-                        line: 0,
+                        line: 1,
                         character: 6,
                     },
                     end: lsp_types::Position {
-                        line: 0,
+                        line: 1,
                         character: 16,
                     },
                 },
@@ -838,11 +990,11 @@ mod tests {
                 uri: Url::parse("file:///mnt/lsproxy_root/sample_project/python/graph.py").unwrap(),
                 range: Range {
                     start: lsp_types::Position {
-                        line: 0,
+                        line: 1,
                         character: 6,
                     },
                     end: lsp_types::Position {
-                        line: 0,
+                        line: 1,
                         character: 16,
                     },
                 },

--- a/lsproxy/src/utils/workspace_documents.rs
+++ b/lsproxy/src/utils/workspace_documents.rs
@@ -32,14 +32,17 @@ pub const PYTHON_ROOT_FILES: &[&str] = &[
     "pyrightconfig.json",
 ];
 
-pub const PYTHON_FILE_PATTERNS: &[&str] = &["**/*.py"];
+pub const PYTHON_FILE_PATTERNS: &[&str] = &["**/*.py", "**/*.pyx", "**/*.pyi"];
+pub const PYTHON_EXTENSIONS: &[&str] = &["py", "pyx", "pyi"];
 
 pub const TYPESCRIPT_ROOT_FILES: &[&str] = &["tsconfig.json", "jsconfig.json", "package.json"];
 
 pub const TYPESCRIPT_FILE_PATTERNS: &[&str] = &["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"];
+pub const TYPESCRIPT_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx"];
 
-pub const RUST_ANALYZER_ROOT_FILES: &[&str] = &["Cargo.toml"];
-pub const RUST_ANALYZER_FILE_PATTERNS: &[&str] = &["**/*.rs"];
+pub const RUST_ROOT_FILES: &[&str] = &["Cargo.toml"];
+pub const RUST_FILE_PATTERNS: &[&str] = &["**/*.rs"];
+pub const RUST_EXTENSIONS: &[&str] = &["rs"];
 
 pub const CPP_ROOT_FILES: &[&str] = &[
     "makefile",
@@ -54,9 +57,11 @@ pub const CPP_ROOT_FILES: &[&str] = &[
 pub const C_AND_CPP_FILE_PATTERNS: &[&str] = &[
     "**/*.cpp", "**/*.cc", "**/*.c", "**/*.cxx", "**/*.h", "**/*.hpp", "**/*.hxx", "**/*.hh",
 ];
+pub const C_AND_CPP_EXTENSIONS: &[&str] = &["cpp", "cc", "c", "cxx", "h", "hpp", "hxx", "hh"];
 
 pub const JAVA_ROOT_FILES: &[&str] = &["gradlew", ".git", "mvnw"];
 pub const JAVA_FILE_PATTERNS: &[&str] = &["**/*.java"];
+pub const JAVA_EXTENSIONS: &[&str] = &["java"];
 
 #[async_trait::async_trait]
 pub trait WorkspaceDocuments: Send + Sync {

--- a/sample_project/python/graph.py
+++ b/sample_project/python/graph.py
@@ -1,3 +1,4 @@
+@setmodule("graph")
 class AStarGraph(object):
     # Define a class board like grid with two barriers
 
@@ -19,6 +20,10 @@ class AStarGraph(object):
                 (3, 2),
             ]
         )
+
+    @property
+    def barriers():
+        return self.barriers
 
     def heuristic(self, start, goal):
         # Use Chebyshev distance heuristic if we can move one square either


### PR DESCRIPTION
## **Description**
- Enhanced language detection by adding file extensions for Python, TypeScript, Rust, C/C++, and Java.
- Improved log message clarity in the `definitions_in_file` handler.
- Updated Rust file patterns and root files usage.
- Added a new test for Python decorators and adjusted existing tests to reflect changes in line numbers.
- Enhanced the function rule to support decorated definitions in YAML configuration.
- Added a `@setmodule` decorator and a `barriers` property to the `AStarGraph` class in the Python sample project.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>definitions_in_file.rs</strong><dd><code>Improve log message clarity in definitions handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/definitions_in_file.rs
- Updated log message for clarity in `definitions_in_file` function.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-906fbe3e00cf3773130258ed90380adea4699ec4da304bfdb5501effa23f7180">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rust.rs</strong><dd><code>Update Rust file patterns and root files usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/rust.rs
<li>Replaced <code>RUST_ANALYZER_FILE_PATTERNS</code> and <code>RUST_ANALYZER_ROOT_FILES</code> with <br><code>RUST_FILE_PATTERNS</code> and <code>RUST_ROOT_FILES</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-3864fddce9f7583765ecf681f071ef95762680e30d561933416ba52aa17a4719">+3/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manager.rs</strong><dd><code>Enhance language detection and add Python decorator test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/manager.rs
<li>Added file extensions for language detection.<br> <li> Updated test cases to reflect changes in line numbers.<br> <li> Added a new test for Python decorators.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-932f8e768420458f1d9090b5b74386a75a75ca9ee0a94b40e525d2b9cb858a38">+175/-19</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workspace_documents.rs</strong><dd><code>Add file extensions for multiple languages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/utils/workspace_documents.rs
<li>Added file extensions for Python, TypeScript, Rust, C/C++, and Java.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-f030f0468e21346b56d10aa90d332c79389ae7030f9ae1d06a0756aeffe1254b">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>graph.py</strong><dd><code>Add decorator and property to AStarGraph class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sample_project/python/graph.py
<li>Added <code>@setmodule</code> decorator to <code>AStarGraph</code> class.<br> <li> Added <code>barriers</code> property method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-c6688076aa86c30d5545c6237c2020bb551b8d8b4c479775475aaa2d59fd9f20">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>function.yml</strong><dd><code>Enhance function rule to support decorated definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/ast_grep/rules/python/function.yml
- Updated rule to include decorated function definitions.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-70d835c421b4f30fa7a08771569a7339dc4034af467ac137ef7de8c65312637b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>find_definition.rs</strong><dd><code>Update test line numbers in find_definition module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/find_definition.rs
<li>Adjusted test data to change line numbers in <code>find_definition</code> tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-c2e457248cfb7a97fddf658529ed364cd1dba73653566a8b9580af0988a0aac9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>find_references.rs</strong><dd><code>Update test line numbers in find_references module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/find_references.rs
<li>Adjusted test data to change line numbers in <code>find_references</code> tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/72/files#diff-2928da39d39611f0c251df367f94bb73421a526d528b3e68fa9f0b5324bc7b6f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
