### PR TITLE
disable syntax server in ts, only use full

### DIFF
--- a/lsproxy/src/lsp/client.rs
+++ b/lsproxy/src/lsp/client.rs
@@ -1,4 +1,4 @@
-use crate::lsp::json_rpc::{JsonRpc, JsonRpcMessage};
+use crate::lsp::json_rpc::JsonRpc;
 use crate::lsp::process::Process;
 use crate::lsp::{ExpectedMessageKey, InnerMessage, JsonRpcHandler, ProcessHandler};
 use crate::utils::file_utils::{detect_language_string, search_directories};

--- a/lsproxy/src/lsp/languages/rust.rs
+++ b/lsproxy/src/lsp/languages/rust.rs
@@ -1,9 +1,8 @@
 use std::{error::Error, path::Path, process::Stdio};
 
 use async_trait::async_trait;
-use log::debug;
 use lsp_types::{
-    ClientCapabilities, DocumentSymbolClientCapabilities, InitializeParams, InitializeResult,
+    ClientCapabilities, DocumentSymbolClientCapabilities, InitializeParams,
     TextDocumentClientCapabilities,
 };
 use notify_debouncer_mini::DebouncedEvent;

--- a/lsproxy/src/lsp/languages/typescript.rs
+++ b/lsproxy/src/lsp/languages/typescript.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 use async_trait::async_trait;
 use json5::from_str as json5_from_str;
 use log::debug;
-use lsp_types::TextDocumentItem;
+use lsp_types::{InitializeParams, TextDocumentItem};
 use notify_debouncer_mini::DebouncedEvent;
 use serde_json::Value;
 use tokio::fs::read_to_string;
@@ -50,6 +50,20 @@ impl LspClient for TypeScriptLanguageClient {
 
     fn get_workspace_documents(&mut self) -> &mut WorkspaceDocumentsHandler {
         &mut self.workspace_documents
+    }
+
+    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
+        let capabilities = self.get_capabilities();
+        InitializeParams {
+            capabilities,
+            root_uri: Some(Url::from_file_path(root_path).unwrap()),
+            initialization_options: Some(serde_json::json!({
+                "tsserver": {
+                    "useSyntaxServer": "never"
+                }
+            })),
+            ..Default::default()
+        }
     }
 }
 

--- a/lsproxy/src/lsp/languages/typescript.rs
+++ b/lsproxy/src/lsp/languages/typescript.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::lsp::{JsonRpcHandler, LspClient, PendingRequests, ProcessHandler};
 
 use crate::utils::workspace_documents::{
-    DidOpenConfiguration, WorkspaceDocuments, WorkspaceDocumentsHandler, DEFAULT_EXCLUDE_PATTERNS,
+    DidOpenConfiguration, WorkspaceDocumentsHandler, DEFAULT_EXCLUDE_PATTERNS,
     TYPESCRIPT_AND_JAVASCRIPT_FILE_PATTERNS, TYPESCRIPT_AND_JAVASCRIPT_ROOT_FILES,
 };
 

--- a/lsproxy/src/lsp/languages/typescript.rs
+++ b/lsproxy/src/lsp/languages/typescript.rs
@@ -1,14 +1,9 @@
-use std::error::Error;
 use std::path::Path;
 use std::process::Stdio;
 
 use async_trait::async_trait;
-use json5::from_str as json5_from_str;
-use log::debug;
-use lsp_types::{InitializeParams, TextDocumentItem};
+use lsp_types::InitializeParams;
 use notify_debouncer_mini::DebouncedEvent;
-use serde_json::Value;
-use tokio::fs::read_to_string;
 use tokio::process::Command;
 use tokio::sync::broadcast::Receiver;
 use url::Url;
@@ -104,67 +99,5 @@ impl TypeScriptLanguageClient {
             workspace_documents,
             pending_requests: PendingRequests::new(),
         })
-    }
-
-    pub async fn get_text_document_items_to_open_with_config(
-        &mut self,
-        workspace_path: &str,
-    ) -> Result<Vec<TextDocumentItem>, Box<dyn Error + Send + Sync>> {
-        let tsconfig_path = Path::new(workspace_path).join("tsconfig.json");
-        let tsconfig_content = read_to_string(tsconfig_path)
-            .await
-            .unwrap_or_else(|_| "{}".to_string());
-        let tsconfig: Value = json5_from_str(&tsconfig_content)?;
-
-        let mut include_patterns = tsconfig["include"]
-            .as_array()
-            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
-            .unwrap_or_else(|| vec![]);
-        if include_patterns.is_empty() {
-            include_patterns = TYPESCRIPT_AND_JAVASCRIPT_FILE_PATTERNS.to_vec();
-        }
-
-        let mut exclude_patterns: Vec<&str> = DEFAULT_EXCLUDE_PATTERNS.to_vec();
-        exclude_patterns.extend(
-            tsconfig["exclude"]
-                .as_array()
-                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>())
-                .unwrap_or_else(|| vec![]),
-        );
-        let workspace_documents = self.get_workspace_documents();
-        workspace_documents
-            .update_patterns(
-                include_patterns
-                    .into_iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-                exclude_patterns
-                    .into_iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-            )
-            .await;
-        let file_paths = workspace_documents.list_files().await;
-        let mut items = Vec::with_capacity(file_paths.len());
-        for file_path in file_paths {
-            let content = match workspace_documents
-                .read_text_document(&file_path, None)
-                .await
-            {
-                Ok(content) => content,
-                Err(e) => {
-                    debug!("Failed to read document {}: {}", file_path.display(), e);
-                    return Err(e);
-                }
-            };
-            let item = TextDocumentItem {
-                uri: Url::from_file_path(file_path).map_err(|_| "Invalid file path")?,
-                language_id: "typescript".to_string(),
-                version: 1,
-                text: content,
-            };
-            items.push(item);
-        }
-        Ok(items)
     }
 }


### PR DESCRIPTION
## **Description**
- Removed unused functions `workspace_symbols` and `receive_response` from the LSP client to streamline the code.
- Refactored the Rust LSP client to separate capability retrieval and initialization parameters, improving code organization.
- Added a new function to the TypeScript LSP client to handle initialization parameters, specifically disabling the syntax server.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Remove unused functions from LSP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/client.rs
<li>Removed unused <code>workspace_symbols</code> function.<br> <li> Removed <code>receive_response</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/86/files#diff-36b320cabc75844e87dcec1ab0abfa27a3f1af02c987a99a756413197d8d7bb9">+0/-56</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rust.rs</strong><dd><code>Refactor Rust LSP client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/rust.rs
<li>Added <code>get_capabilities</code> function to return client capabilities.<br> <li> Refactored initialization to use <code>get_initialize_params</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/86/files#diff-3864fddce9f7583765ecf681f071ef95762680e30d561933416ba52aa17a4719">+15/-26</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>typescript.rs</strong><dd><code>Add initialization parameters for TypeScript LSP client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/typescript.rs
<li>Added <code>get_initialize_params</code> function for TypeScript client.<br> <li> Disabled syntax server in TypeScript initialization options.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/86/files#diff-50411b43b20dfc0e662ed33b15123b86b3aef5af826cafbe0703a56d53a3558d">+15/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
