### PR TITLE
Add health check endpoint

### DIFF
--- a/.github/workflows/image_upload.yml
+++ b/.github/workflows/image_upload.yml
@@ -13,12 +13,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Validate script version
+      - name: Validate versions
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
+          
+          # Check install script version
           SCRIPT_VERSION=$(grep "LSPROXY_VERSION=" release/install-lsproxy.sh | cut -d'"' -f2)
           if [ "$VERSION" != "$SCRIPT_VERSION" ]; then
             echo "Error: Script version ($SCRIPT_VERSION) does not match release tag ($VERSION)"
+            exit 1
+          fi
+          
+          # Check Cargo.toml version
+          CARGO_VERSION=$(grep '^version = ' lsproxy/Cargo.toml | cut -d'"' -f2)
+          if [ "$VERSION" != "$CARGO_VERSION" ]; then
+            echo "Error: Cargo.toml version ($CARGO_VERSION) does not match release tag ($VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/image_upload.yml
+++ b/.github/workflows/image_upload.yml
@@ -13,18 +13,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Validate versions
+      - name: Validate install script version
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
-          
-          # Check install script version
           SCRIPT_VERSION=$(grep "LSPROXY_VERSION=" release/install-lsproxy.sh | cut -d'"' -f2)
           if [ "$VERSION" != "$SCRIPT_VERSION" ]; then
             echo "Error: Script version ($SCRIPT_VERSION) does not match release tag ($VERSION)"
             exit 1
           fi
-          
-          # Check Cargo.toml version
+
+      - name: Validate Cargo.toml version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
           CARGO_VERSION=$(grep '^version = ' lsproxy/Cargo.toml | cut -d'"' -f2)
           if [ "$VERSION" != "$CARGO_VERSION" ]; then
             echo "Error: Cargo.toml version ($CARGO_VERSION) does not match release tag ($VERSION)"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ compile_commands.json
 **/jdt.ls-java-project/**
 .project
 .classpath
+.env

--- a/lsproxy/Cargo.toml
+++ b/lsproxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsproxy"
-version = "0.1.11"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/lsproxy/src/api_types.rs
+++ b/lsproxy/src/api_types.rs
@@ -1,6 +1,7 @@
 use log::warn;
 use lsp_types::{GotoDefinitionResponse, Location, LocationLink};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use serde_json::{to_value, Value};
 use std::cell::RefCell;
 use std::hash::Hash;
@@ -47,6 +48,13 @@ pub fn set_global_mount_dir(path: impl AsRef<Path>) {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ErrorResponse {
     pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct HealthResponse {
+    pub status: String,
+    pub version: String,
+    pub languages: HashMap<SupportedLanguages, bool>,
 }
 
 #[derive(

--- a/lsproxy/src/api_types.rs
+++ b/lsproxy/src/api_types.rs
@@ -1,9 +1,9 @@
 use log::warn;
 use lsp_types::{GotoDefinitionResponse, Location, LocationLink};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use serde_json::{to_value, Value};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock};

--- a/lsproxy/src/handlers/health.rs
+++ b/lsproxy/src/handlers/health.rs
@@ -11,7 +11,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Returns the service status, version and language server availability
 #[utoipa::path(
     get,
-    path = "/health",
+    path = "/system/health",
     tag = "system",
     responses(
         (status = 200, description = "Health check successful", body = HealthResponse),

--- a/lsproxy/src/handlers/health.rs
+++ b/lsproxy/src/handlers/health.rs
@@ -1,0 +1,46 @@
+use crate::api_types::{HealthResponse, SupportedLanguages};
+use crate::AppState;
+use actix_web::web::Data;
+use actix_web::HttpResponse;
+use std::collections::HashMap;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Get health status of the LSP proxy service
+///
+/// Returns the service status, version and language server availability
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "system",
+    responses(
+        (status = 200, description = "Health check successful", body = HealthResponse),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn health_check(data: Data<AppState>) -> HttpResponse {
+    let manager = match data.manager.lock() {
+        Ok(manager) => manager,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(format!("Failed to lock manager: {}", e))
+        }
+    };
+
+    let mut languages = HashMap::new();
+    for lang in [
+        SupportedLanguages::Python,
+        SupportedLanguages::TypeScriptJavaScript,
+        SupportedLanguages::Rust,
+        SupportedLanguages::CPP,
+        SupportedLanguages::Java,
+        SupportedLanguages::Golang,
+    ] {
+        languages.insert(lang, manager.get_client(lang).is_some());
+    }
+
+    HttpResponse::Ok().json(HealthResponse {
+        status: "ok".to_string(),
+        version: VERSION.to_string(),
+        languages,
+    })
+}

--- a/lsproxy/src/handlers/health.rs
+++ b/lsproxy/src/handlers/health.rs
@@ -22,7 +22,8 @@ pub async fn health_check(data: Data<AppState>) -> HttpResponse {
     let manager = match data.manager.lock() {
         Ok(manager) => manager,
         Err(e) => {
-            return HttpResponse::InternalServerError().json(format!("Failed to lock manager: {}", e))
+            return HttpResponse::InternalServerError()
+                .json(format!("Failed to lock manager: {}", e))
         }
     };
 

--- a/lsproxy/src/handlers/mod.rs
+++ b/lsproxy/src/handlers/mod.rs
@@ -1,9 +1,10 @@
 mod definitions_in_file;
 mod find_definition;
 mod find_references;
+mod health;
 mod list_files;
 mod read_source_code;
 pub use self::{
-    definitions_in_file::*, find_definition::*, find_references::*, list_files::*,
+    definitions_in_file::*, find_definition::*, find_references::*, health::*, list_files::*,
     read_source_code::*,
 };

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -41,7 +41,7 @@ pub fn check_mount_dir() -> std::io::Result<()> {
 #[openapi(
     info(
         title = "lsproxy",
-        version = "0.1.1",
+        version = "0.1.2",
         license(
             name = "Apache-2.0",
             url = "https://www.apache.org/licenses/LICENSE-2.0"
@@ -209,7 +209,7 @@ pub async fn run_server_with_port_and_host(
                 ("/workspace/read-source-code", Some(Method::Post)) =>
                     api_scope.service(resource(path).route(post().to(read_source_code))),
                 ("/system/health", Some(Method::Get)) =>
-                    api_scope.service(resource(path).route(post().to(health_check))),
+                    api_scope.service(resource(path).route(get().to(health_check))),
                 (p, m) => panic!(
                     "Invalid path configuration for {}: {:?}. Ensure the OpenAPI spec matches your handlers.", 
                     p,

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -64,12 +64,14 @@ pub fn check_mount_dir() -> std::io::Result<()> {
             ErrorResponse,
             CodeContext,
             FileRange,
+            HealthResponse,
         )
     ),
     paths(
         crate::handlers::definitions_in_file,
         crate::handlers::find_definition,
         crate::handlers::find_references,
+        crate::handlers::health_check,
         crate::handlers::list_files,
         crate::handlers::read_source_code,
     ),

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -4,7 +4,6 @@ use actix_web::{
     web::{get, post, resource, scope, Data},
     App, HttpServer,
 };
-use api_types::{CodeContext, ErrorResponse, FileRange, Position};
 use handlers::read_source_code;
 use log::warn;
 use middleware::{validate_jwt_config, JwtMiddleware};
@@ -23,11 +22,13 @@ mod lsp;
 mod utils;
 
 use crate::api_types::{
-    get_mount_dir, set_global_mount_dir, DefinitionResponse, FilePosition, FileSymbolsRequest,
-    GetDefinitionRequest, GetReferencesRequest, ReferencesResponse, SupportedLanguages, Symbol,
-    SymbolResponse,
+    get_mount_dir, set_global_mount_dir, CodeContext, DefinitionResponse, ErrorResponse,
+    FilePosition, FileRange, FileSymbolsRequest, GetDefinitionRequest, GetReferencesRequest,
+    HealthResponse, Position, ReferencesResponse, SupportedLanguages, Symbol, SymbolResponse,
 };
-use crate::handlers::{definitions_in_file, find_definition, find_references, list_files};
+use crate::handlers::{
+    definitions_in_file, find_definition, find_references, health_check, list_files,
+};
 use crate::lsp::manager::Manager;
 // use crate::utils::doc_utils::make_code_sample;
 
@@ -175,7 +176,7 @@ pub async fn run_server_with_port_and_host(
         .and_then(|path| path.strip_prefix('/').map(|s| s.to_string())) // Convert stripped result to String
         .unwrap_or_else(|| String::new()); // Use empty string as default
 
-    let jwt_secret = match validate_jwt_config() {
+    match validate_jwt_config() {
         Ok(secret) => secret,
         Err(e) => {
             eprintln!("Configuration error: {}", e);
@@ -207,6 +208,8 @@ pub async fn run_server_with_port_and_host(
                     api_scope.service(resource(path).route(get().to(list_files))),
                 ("/workspace/read-source-code", Some(Method::Post)) =>
                     api_scope.service(resource(path).route(post().to(read_source_code))),
+                ("/system/health", Some(Method::Get)) =>
+                    api_scope.service(resource(path).route(post().to(health_check))),
                 (p, m) => panic!(
                     "Invalid path configuration for {}: {:?}. Ensure the OpenAPI spec matches your handlers.", 
                     p,

--- a/lsproxy/tests/java_test.rs
+++ b/lsproxy/tests/java_test.rs
@@ -3,14 +3,13 @@ use lsproxy::api_types::{
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
-use std::net::TcpStream;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
 fn wait_for_server(base_url: &str) {
     let client = reqwest::blocking::Client::new();
-    let health_url = format!("{}/system/health", base_url);
+    let health_url = format!("{}/v1/system/health", base_url);
     
     for _ in 0..30 {
         // Try for 30 seconds

--- a/lsproxy/tests/java_test.rs
+++ b/lsproxy/tests/java_test.rs
@@ -1,5 +1,5 @@
 use lsproxy::api_types::{
-    set_global_mount_dir, FilePosition, FileRange, Position, Symbol, SymbolResponse,
+    set_global_mount_dir, FilePosition, FileRange, Position, Symbol, SymbolResponse, HealthResponse,
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
@@ -8,16 +8,22 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-fn wait_for_server(url: &str) {
+fn wait_for_server(base_url: &str) {
     let client = reqwest::blocking::Client::new();
+    let health_url = format!("{}/system/health", base_url);
+    
     for _ in 0..30 {
         // Try for 30 seconds
-        if client.get(url).send().is_ok() {
-            return;
+        if let Ok(response) = client.get(&health_url).send() {
+            if let Ok(health) = response.json::<HealthResponse>() {
+                if health.status == "ok" {
+                    return;
+                }
+            }
         }
         thread::sleep(Duration::from_secs(1));
     }
-    panic!("Server did not respond within 30 seconds");
+    panic!("Server did not respond with healthy status within 30 seconds");
 }
 
 #[test]
@@ -55,13 +61,8 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error_msg.into());
     }
 
-    // Check if the server is running
-    match TcpStream::connect("0.0.0.0:4444") {
-        Ok(_) => println!("Server is running"),
-        Err(e) => return Err(format!("Failed to connect to server: {}", e).into()),
-    }
     let base_url = "http://localhost:4444";
-    wait_for_server(&format!("{}/v1/workspace/list-files", base_url));
+    wait_for_server(base_url);
 
     let client = reqwest::blocking::Client::new();
     // Test workspace/list-files endpoint

--- a/lsproxy/tests/python_test.rs
+++ b/lsproxy/tests/python_test.rs
@@ -1,5 +1,5 @@
 use lsproxy::api_types::{
-    set_global_mount_dir, FilePosition, FileRange, Position, Symbol, SymbolResponse,
+    set_global_mount_dir, FilePosition, FileRange, Position, Symbol, SymbolResponse, HealthResponse,
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
@@ -8,16 +8,22 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-fn wait_for_server(url: &str) {
+fn wait_for_server(base_url: &str) {
     let client = reqwest::blocking::Client::new();
+    let health_url = format!("{}/system/health", base_url);
+    
     for _ in 0..30 {
         // Try for 30 seconds
-        if client.get(url).send().is_ok() {
-            return;
+        if let Ok(response) = client.get(&health_url).send() {
+            if let Ok(health) = response.json::<HealthResponse>() {
+                if health.status == "ok" {
+                    return;
+                }
+            }
         }
         thread::sleep(Duration::from_secs(1));
     }
-    panic!("Server did not respond within 30 seconds");
+    panic!("Server did not respond with healthy status within 30 seconds");
 }
 
 #[test]
@@ -54,13 +60,8 @@ fn test_server_integration_python() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error_msg.into());
     }
 
-    // Check if the server is running
-    match TcpStream::connect("0.0.0.0:4444") {
-        Ok(_) => println!("Server is running"),
-        Err(e) => return Err(format!("Failed to connect to server: {}", e).into()),
-    }
     let base_url = "http://localhost:4444";
-    wait_for_server(&format!("{}/v1/workspace/list-files", base_url));
+    wait_for_server(base_url);
 
     let client = reqwest::blocking::Client::new();
     // Test workspace/list-files endpoint

--- a/lsproxy/tests/python_test.rs
+++ b/lsproxy/tests/python_test.rs
@@ -3,7 +3,6 @@ use lsproxy::api_types::{
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
-use std::net::TcpStream;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;

--- a/lsproxy/tests/python_test.rs
+++ b/lsproxy/tests/python_test.rs
@@ -34,6 +34,7 @@ fn test_server_integration_python() -> Result<(), Box<dyn std::error::Error>> {
 
     // Spawn the server in a separate thread
     let _server_thread = thread::spawn(move || {
+        std::env::set_var("USE_AUTH", "false");
         set_global_mount_dir(&mount_dir);
 
         let system = actix_web::rt::System::new();

--- a/lsproxy/tests/python_test.rs
+++ b/lsproxy/tests/python_test.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 fn wait_for_server(base_url: &str) {
     let client = reqwest::blocking::Client::new();
-    let health_url = format!("{}/system/health", base_url);
+    let health_url = format!("{}/v1/system/health", base_url);
     
     for _ in 0..30 {
         // Try for 30 seconds

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "servers": [
     {
@@ -127,6 +127,31 @@
           },
           "400": {
             "description": "Bad request"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/system/health": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Get health status of the LSP proxy service",
+        "description": "Returns the service status, version and language server availability",
+        "operationId": "health_check",
+        "responses": {
+          "200": {
+            "description": "Health check successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error"
@@ -358,6 +383,39 @@
             "type": "boolean",
             "description": "Whether to include the raw response from the langserver in the response.\nDefaults to false.",
             "example": false
+          }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "version",
+          "languages"
+        ],
+        "properties": {
+          "languages": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string",
+              "enum": [
+                "python",
+                "typescript_javascript",
+                "rust",
+                "cpp",
+                "java",
+                "golang"
+              ]
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
           }
         }
       },

--- a/release/install-lsproxy.sh
+++ b/release/install-lsproxy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-LSPROXY_VERSION="0.2.0"
+LSPROXY_VERSION="0.2.1"
 
 # Function to detect architecture
 detect_arch() {


### PR DESCRIPTION
## **Description**
- Added a new health check endpoint to the LSP proxy service, providing service status, version, and language server availability.
- Introduced a new `HealthResponse` struct to encapsulate health check response data.
- Updated tests to utilize the new health check endpoint instead of TCP connection checks.
- Bumped the package version to 0.2.1 and updated the installation script accordingly.
- Enhanced the OpenAPI specification to include the health check endpoint.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>api_types.rs</strong><dd><code>Add HealthResponse struct for health check API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/api_types.rs
<li>Added a new struct <code>HealthResponse</code> to represent health check responses.<br> <li> Included <code>HashMap</code> for language server availability in <code>HealthResponse</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-18c0dbf0ba09194cd0719ebd4862de79ce4d68e67f81dac5142d4dfcf12d2085">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>health.rs</strong><dd><code>Implement health check endpoint for service status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/health.rs
<li>Implemented a new health check endpoint.<br> <li> Returns service status, version, and language server availability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-405403dd491c7c7993202e8f6d7e012a21a1b3a1c7ad07ee3aeba064b56275ab">+47/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Integrate health module into handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/mod.rs
- Added health module to handlers.
- Exported health check function.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-b252c8466729a343d9086994dce0abfee45d35d9c2638a8a81c162c32ef70189">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Register health check endpoint and update API version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lib.rs
<li>Registered health check endpoint in the server.<br> <li> Updated API version to 0.1.2.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-53708e4140a781f3947933d6e52e5b632e2601fd242c72f3ef8812284fe43b53">+12/-7</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>java_test.rs</strong><dd><code>Use health check endpoint in Java tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/tests/java_test.rs
<li>Replaced TCP connection check with health check endpoint.<br> <li> Updated test to use health check for server readiness.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-081460e79a4043cef723f4c75940270b39e9084b7f9bf5aa700a40c021d4134e">+12/-12</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>python_test.rs</strong><dd><code>Use health check endpoint in Python tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/tests/python_test.rs
<li>Replaced TCP connection check with health check endpoint.<br> <li> Updated test to use health check for server readiness.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-0ee18da8ba0b4a24898012e01a34514268bd5c8fe4b067da2a0f0c3e3c04bf08">+13/-12</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>install-lsproxy.sh</strong><dd><code>Update LSPROXY_VERSION in installation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release/install-lsproxy.sh
- Updated LSPROXY_VERSION from 0.2.0 to 0.2.1.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-a03f4096506658ed42c382b938b947ca3214c7a22c2dea180a5ee44d125feedc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump package version to 0.2.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/Cargo.toml
- Updated package version from 0.1.11 to 0.2.1.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-40141d3c092b15901e8b921438b1c1f845274b01873b8d8541962775aa19e1f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.json</strong><dd><code>Add health check endpoint to OpenAPI spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi.json
<li>Added health check endpoint to OpenAPI specification.<br> <li> Updated API version to 0.1.2.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/96/files#diff-a9865368a7fc7fa33065e35b2343f10d08fb79d65205435403d0a163a3044713">+59/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details><summary><strong>🔍 Infra Scan Results:</strong></summary><hr>
<table><tr><td><details><summary><strong>Failed Openapi Checks</strong></summary><div><table><tr><th>Check Name</th><th>File Path</th><th>Lines</th></tr><tr><td>Ensure that arrays have a maximum number of items</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3a7e2f2ec159aadec214a767d27511a76abe374c/openapi.json#L43:L48' target='_blank'>43-48</a></td></tr><tr><td>Ensure that security schemes don't allow cleartext credentials over unencrypted channel - version 3.x.y files</td><td>openapi.json</td><td><a href='https://github.com/agentic-labs/lsproxy/blob/3a7e2f2ec159aadec214a767d27511a76abe374c/openapi.json#L558:L562' target='_blank'>558-562</a></td></tr></table></div></details></td></tr></table></details><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
