### PR TITLE
Better error handling

### DIFF
--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -139,7 +139,7 @@ async fn fetch_definition_source_code(
                 warn!("No exact match in file symbols (likely filtered out). Returning an approximate range instead.");
                 let range = Range {
                     start: LspPosition {
-                        line: definition.range.start.line as u32,
+                        line: definition.range.start.line.saturating_sub(3),
                         character: 0,
                     },
                     end: LspPosition {
@@ -154,7 +154,7 @@ async fn fetch_definition_source_code(
                     range: FileRange {
                         path: relative_path,
                         start: Position {
-                            line: definition.range.start.line as u32,
+                            line: definition.range.start.line.saturating_sub(3),
                             character: 0,
                         },
                         end: Position {

--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -7,7 +7,7 @@ use log::{error, info, warn};
 
 use crate::api_types::{DefinitionResponse, GetDefinitionRequest};
 use crate::AppState;
-use lsp_types::{GotoDefinitionResponse, Location, Position as LspPosition};
+use lsp_types::{GotoDefinitionResponse, Location, Position as LspPosition, Range};
 /// Get the definition of a symbol at a specific position in a file
 ///
 /// Returns the location of the definition for the symbol at the given position.
@@ -119,19 +119,8 @@ async fn fetch_definition_source_code(
                 && s.range.start.column as u32 == definition.range.start.character
         });
 
-        let source_code = match symbol {
-            Some(symbol) => symbol.get_source_code(),
-            None => {
-                warn!("Symbol not found for definition: {:?}", definition);
-                return Err(LspManagerError::InternalError(format!(
-                    "Symbol not found for definition at {:?}",
-                    definition
-                )));
-            }
-        };
-
-        if let Some(symbol) = symbol {
-            code_contexts.push(CodeContext {
+        let source_code_context = match symbol {
+            Some(symbol) => CodeContext {
                 range: FileRange {
                     path: relative_path,
                     start: Position {
@@ -143,9 +132,42 @@ async fn fetch_definition_source_code(
                         character: symbol.meta_variables.single.context.range.end.column as u32,
                     },
                 },
-                source_code,
-            });
-        }
+                source_code: symbol.get_source_code(),
+            },
+            None => {
+                warn!("Symbol not found for definition: {:?}", definition);
+                warn!("No exact match in file symbols (likely filtered out). Returning an approximate range instead.");
+                let range = Range {
+                    start: LspPosition {
+                        line: definition.range.start.line as u32,
+                        character: 0,
+                    },
+                    end: LspPosition {
+                        line: definition.range.end.line as u32 + 3,
+                        character: 0,
+                    },
+                };
+                let source_code = manager
+                    .read_source_code(&relative_path, Some(range))
+                    .await?;
+                CodeContext {
+                    range: FileRange {
+                        path: relative_path,
+                        start: Position {
+                            line: definition.range.start.line as u32,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: definition.range.end.line as u32 + 3,
+                            character: 0,
+                        },
+                    },
+                    source_code,
+                }
+            }
+        };
+
+        code_contexts.push(source_code_context);
     }
     Ok(code_contexts)
 }

--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -76,8 +76,6 @@ pub async fn find_definition(
         }
     };
 
-    info!("Definitions: {:?}", definitions);
-
     let source_code_context = if info.include_source_code {
         match fetch_definition_source_code(&manager, &definitions).await {
             Ok(context) => Some(context),

--- a/lsproxy/src/lsp/client.rs
+++ b/lsproxy/src/lsp/client.rs
@@ -29,7 +29,7 @@ pub trait LspClient: Send {
         debug!("Initializing LSP client with root path: {:?}", root_path);
         self.start_response_listener().await?;
 
-        let params = self.get_initialize_params(root_path).await;
+        let params = self.get_initialize_params(root_path).await?;
 
         let result = self
             .send_request("initialize", Some(serde_json::to_value(params)?))
@@ -64,17 +64,17 @@ pub trait LspClient: Send {
         capabilities
     }
 
-    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
-        InitializeParams {
+    async fn get_initialize_params(
+        &mut self,
+        root_path: String,
+    ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
+        let workspace_folders = self.find_workspace_folders(root_path.clone()).await?;
+        Ok(InitializeParams {
             capabilities: self.get_capabilities(),
-            workspace_folders: Some(
-                self.find_workspace_folders(root_path.clone())
-                    .await
-                    .unwrap_or_default(),
-            ),
+            workspace_folders: Some(workspace_folders),
             root_uri: Some(Url::from_file_path(&root_path).unwrap()), // primarily for python
             ..Default::default()
-        }
+        })
     }
 
     async fn send_request(

--- a/lsproxy/src/lsp/client.rs
+++ b/lsproxy/src/lsp/client.rs
@@ -70,7 +70,7 @@ pub trait LspClient: Send {
             workspace_folders: Some(
                 self.find_workspace_folders(root_path.clone())
                     .await
-                    .unwrap(),
+                    .unwrap_or_default(),
             ),
             root_uri: Some(Url::from_file_path(&root_path).unwrap()), // primarily for python
             ..Default::default()

--- a/lsproxy/src/lsp/languages/clang.rs
+++ b/lsproxy/src/lsp/languages/clang.rs
@@ -81,16 +81,19 @@ impl LspClient for ClangdClient {
         Ok(())
     }
 
-    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
+    async fn get_initialize_params(
+        &mut self,
+        root_path: String,
+    ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
         let capabilities = self.get_capabilities();
-        InitializeParams {
+        Ok(InitializeParams {
             capabilities,
-            root_uri: Some(Url::from_file_path(root_path).unwrap()),
+            root_uri: Some(Url::from_file_path(&root_path).map_err(|_| "Invalid root path")?),
             initialization_options: Some(serde_json::json!({
                 "clangdFileStatus": true, // TODO: actually wait for the status when hitting a file
             })),
             ..Default::default()
-        }
+        })
     }
 
     async fn text_document_did_open(

--- a/lsproxy/src/lsp/languages/golang.rs
+++ b/lsproxy/src/lsp/languages/golang.rs
@@ -40,8 +40,7 @@ impl LspClient for GoplsClient {
     ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
         let workspace_folders = self
             .find_workspace_folders(root_path.clone())
-            .await
-            .unwrap();
+            .await?;
         Ok(InitializeParams {
             capabilities: self.get_capabilities(),
             workspace_folders: Some(workspace_folders.clone()),

--- a/lsproxy/src/lsp/languages/golang.rs
+++ b/lsproxy/src/lsp/languages/golang.rs
@@ -8,7 +8,7 @@ use crate::{
 use async_trait::async_trait;
 use lsp_types::InitializeParams;
 use notify_debouncer_mini::DebouncedEvent;
-use std::{path::Path, process::Stdio};
+use std::{error::Error, path::Path, process::Stdio};
 use tokio::{process::Command, sync::broadcast::Receiver};
 pub struct GoplsClient {
     process: ProcessHandler,
@@ -34,17 +34,20 @@ impl LspClient for GoplsClient {
         &mut self.pending_requests
     }
 
-    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
+    async fn get_initialize_params(
+        &mut self,
+        root_path: String,
+    ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
         let workspace_folders = self
             .find_workspace_folders(root_path.clone())
             .await
             .unwrap();
-        InitializeParams {
+        Ok(InitializeParams {
             capabilities: self.get_capabilities(),
             workspace_folders: Some(workspace_folders.clone()),
             root_uri: workspace_folders.first().map(|f| f.uri.clone()), // <--------- Not default behavior
             ..Default::default()
-        }
+        })
     }
 }
 impl GoplsClient {

--- a/lsproxy/src/lsp/languages/golang.rs
+++ b/lsproxy/src/lsp/languages/golang.rs
@@ -38,9 +38,7 @@ impl LspClient for GoplsClient {
         &mut self,
         root_path: String,
     ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
-        let workspace_folders = self
-            .find_workspace_folders(root_path.clone())
-            .await?;
+        let workspace_folders = self.find_workspace_folders(root_path.clone()).await?;
         Ok(InitializeParams {
             capabilities: self.get_capabilities(),
             workspace_folders: Some(workspace_folders.clone()),

--- a/lsproxy/src/lsp/languages/java.rs
+++ b/lsproxy/src/lsp/languages/java.rs
@@ -50,7 +50,7 @@ impl LspClient for JdtlsClient {
         debug!("Initializing LSP client with root path: {:?}", root_path);
         self.start_response_listener().await?;
 
-        let params = self.get_initialize_params(root_path).await;
+        let params = self.get_initialize_params(root_path).await?;
 
         let result = self
             .send_request("initialize", Some(serde_json::to_value(params)?))

--- a/lsproxy/src/lsp/languages/rust.rs
+++ b/lsproxy/src/lsp/languages/rust.rs
@@ -42,22 +42,25 @@ impl LspClient for RustAnalyzerClient {
         capabilities
     }
 
-    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
-        InitializeParams {
+    async fn get_initialize_params(
+        &mut self,
+        root_path: String,
+    ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
+        Ok(InitializeParams {
             capabilities: self.get_capabilities(),
             workspace_folders: Some(
                 self.find_workspace_folders(root_path.clone())
                     .await
                     .unwrap(),
             ),
-            root_uri: Some(Url::from_file_path(&root_path).unwrap()),
+            root_uri: Some(Url::from_file_path(&root_path).map_err(|_| "Invalid root path")?),
             initialization_options: Some(serde_json::json!({
                 "cargo": {
                     "sysroot": serde_json::Value::Null
                 }
             })),
             ..Default::default()
-        }
+        })
     }
 
     fn get_process(&mut self) -> &mut ProcessHandler {

--- a/lsproxy/src/lsp/languages/typescript.rs
+++ b/lsproxy/src/lsp/languages/typescript.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::path::Path;
 use std::process::Stdio;
 
@@ -47,18 +48,21 @@ impl LspClient for TypeScriptLanguageClient {
         &mut self.workspace_documents
     }
 
-    async fn get_initialize_params(&mut self, root_path: String) -> InitializeParams {
+    async fn get_initialize_params(
+        &mut self,
+        root_path: String,
+    ) -> Result<InitializeParams, Box<dyn Error + Send + Sync>> {
         let capabilities = self.get_capabilities();
-        InitializeParams {
+        Ok(InitializeParams {
             capabilities,
-            root_uri: Some(Url::from_file_path(root_path).unwrap()),
+            root_uri: Some(Url::from_file_path(root_path).map_err(|_| "Invalid root path")?),
             initialization_options: Some(serde_json::json!({
                 "tsserver": {
                     "useSyntaxServer": "never"
                 }
             })),
             ..Default::default()
-        }
+        })
     }
 }
 

--- a/lsproxy/src/lsp/process.rs
+++ b/lsproxy/src/lsp/process.rs
@@ -49,7 +49,10 @@ impl Process for ProcessHandler {
 
             let line = String::from_utf8_lossy(&buffer[buffer.len() - n..]);
             if line.trim().is_empty() && content_length.is_some() {
-                let length = content_length.unwrap();
+                let length = content_length.unwrap_or_else(|| {
+                    log::warn!("Content length is 0, this may indicate a protocol error");
+                    0
+                });
                 let mut content = vec![0; length];
                 stdout.read_exact(&mut content).await?;
                 return Ok(String::from_utf8(content)?);

--- a/lsproxy/src/lsp/process.rs
+++ b/lsproxy/src/lsp/process.rs
@@ -49,10 +49,8 @@ impl Process for ProcessHandler {
 
             let line = String::from_utf8_lossy(&buffer[buffer.len() - n..]);
             if line.trim().is_empty() && content_length.is_some() {
-                let length = content_length.unwrap_or_else(|| {
-                    log::warn!("Content length is 0, this may indicate a protocol error");
-                    0
-                });
+                let length =
+                    content_length.ok_or("Missing Content-Length header in LSP message")?;
                 let mut content = vec![0; length];
                 stdout.read_exact(&mut content).await?;
                 return Ok(String::from_utf8(content)?);


### PR DESCRIPTION
## **Description**
- Refactored error handling across multiple LSP handler functions to use `match` statements, improving clarity and robustness.
- Enhanced the `find_definition` function with better logging and a fallback mechanism for source code context when symbols are missing.
- Updated `get_initialize_params` in various LSP client implementations to return a `Result`, adding error handling for invalid root paths.
- Improved error handling for manager lock acquisition in `find_references` and `list_files` functions.
- Refactored test assertions in `find_references` to handle missing headers gracefully.
- Fixed potential bug in `ProcessHandler` by handling missing Content-Length headers.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>find_definition.rs</strong><dd><code>Refactor error handling and enhance definition fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/find_definition.rs
<li>Refactored error handling using <code>match</code> statements.<br> <li> Improved logging for missing symbols in definitions.<br> <li> Added fallback mechanism for source code context.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-c2e457248cfb7a97fddf658529ed364cd1dba73653566a8b9580af0988a0aac9">+56/-31</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>find_references.rs</strong><dd><code>Improve error handling and refactor test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/find_references.rs
<li>Improved error handling for manager lock acquisition.<br> <li> Refactored test assertions for content-type header.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-2928da39d39611f0c251df367f94bb73421a526d528b3e68fa9f0b5324bc7b6f">+26/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>list_files.rs</strong><dd><code>Enhance error handling in list_files function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/handlers/list_files.rs
- Enhanced error handling for manager lock acquisition.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-fb7acfdf5c96b5e3d44cdf85aa94de3fe5dd16216cd497612f5f69ab2a6b941e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Modify get_initialize_params to return Result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/client.rs
- Changed `get_initialize_params` to return a `Result`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-36b320cabc75844e87dcec1ab0abfa27a3f1af02c987a99a756413197d8d7bb9">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>clang.rs</strong><dd><code>Update get_initialize_params to return Result in ClangdClient</code>&nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/clang.rs
- Updated `get_initialize_params` to return a `Result`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-309bdd216071cd9e2233d3ca61e3cb1cc04d537b31dcb8ebc0e6dad2da206e56">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>golang.rs</strong><dd><code>Update get_initialize_params to return Result in GoplsClient</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/golang.rs
<li>Updated <code>get_initialize_params</code> to return a <code>Result</code>.<br> <li> Added error handling for invalid root path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-be651040235e8e213f6c9e52f4b32f56723fbce1b4b8685d57bf18643283cecb">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>java.rs</strong><dd><code>Modify get_initialize_params to return Result in JdtlsClient</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/languages/java.rs
- Modified `get_initialize_params` to return a `Result`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-ccd6a14091400a980e3470b9f4aa0c170f9bb913de46016adb33896fa860b346">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>php.rs</strong><dd><code>Update get_initialize_params to return Result in PhpactorClient</code></dd></summary>
<hr>

lsproxy/src/lsp/languages/php.rs
<li>Updated <code>get_initialize_params</code> to return a <code>Result</code>.<br> <li> Added error handling for invalid root path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-a365f922464ba659d63a2766410f0c0cfb29cb2f7692a5849aa82d26151a1c39">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rust.rs</strong><dd><code>Modify get_initialize_params to return Result in RustAnalyzerClient</code></dd></summary>
<hr>

lsproxy/src/lsp/languages/rust.rs
- Modified `get_initialize_params` to return a `Result`.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-3864fddce9f7583765ecf681f071ef95762680e30d561933416ba52aa17a4719">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>typescript.rs</strong><dd><code>Update get_initialize_params to return Result in <br>TypeScriptLanguageClient</code></dd></summary>
<hr>

lsproxy/src/lsp/languages/typescript.rs
<li>Updated <code>get_initialize_params</code> to return a <code>Result</code>.<br> <li> Added error handling for invalid root path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-50411b43b20dfc0e662ed33b15123b86b3aef5af826cafbe0703a56d53a3558d">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>process.rs</strong><dd><code>Improve error handling for Content-Length in ProcessHandler</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/process.rs
- Improved handling of missing Content-Length header.



</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/103/files#diff-b6e322adb00a8384109d307debc70cb2fef0bc6fe5de595773e5bee73b7e8fbc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
