### PR TITLE
Fix location checking

### DIFF
--- a/lsproxy/src/ast_grep/client.rs
+++ b/lsproxy/src/ast_grep/client.rs
@@ -67,11 +67,10 @@ impl AstGrepClient {
         let contained_references = matches
             .into_iter()
             .filter(|m| {
-                let position_matches = symbol_match
-                    .get_context_range()
-                    .contains_position(&m.get_identifier_range().start);
+                let contained = symbol_match
+                    .contains(m);
 
-                position_matches && (full_scan || m.rule_id != "non-function")
+                contained && (full_scan || m.rule_id != "non-function")
             })
             .collect();
 

--- a/lsproxy/src/ast_grep/types.rs
+++ b/lsproxy/src/ast_grep/types.rs
@@ -41,6 +41,31 @@ impl AstGrepMatch {
     pub fn get_identifier_range(&self) -> AstGrepRange {
         self.meta_variables.single.name.range.clone()
     }
+
+    pub fn contains(&self, other: &AstGrepMatch) -> bool {
+        self.file == other.file
+            && self.get_context_range().start.line <= other.get_context_range().start.line
+            && self.get_context_range().end.line >= other.get_context_range().end.line
+            && (self.get_context_range().start.line != other.get_context_range().start.line || self.get_context_range().start.column <= other.get_context_range().start.column)
+            && (self.get_context_range().end.line != other.get_context_range().end.line || self.get_context_range().end.column >= other.get_context_range().end.column)
+    }
+
+    pub fn contains_location(&self, loc: &lsp_types::Location) -> bool {
+        self.file == loc.uri.path()
+            && self.get_context_range().start.line <= loc.range.start.line
+            && self.get_context_range().end.line >= loc.range.end.line
+            && (self.get_context_range().start.line != loc.range.start.line || self.get_context_range().start.column <= loc.range.start.character)
+            && (self.get_context_range().end.line != loc.range.end.line || self.get_context_range().end.column >= loc.range.end.character)
+
+    }
+
+    pub fn contains_locationlink(&self, link: &lsp_types::LocationLink) -> bool {
+        self.file == link.target_uri.path()
+            && self.get_context_range().start.line <= link.target_range.start.line
+            && self.get_context_range().end.line >= link.target_range.end.line
+            && (self.get_context_range().start.line != link.target_range.start.line || self.get_context_range().start.column <= link.target_range.start.character)
+            && (self.get_context_range().end.line != link.target_range.end.line || self.get_context_range().end.column >= link.target_range.end.character)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -49,15 +74,6 @@ pub struct AstGrepRange {
     pub byte_offset: ByteOffset,
     pub start: AstGrepPosition,
     pub end: AstGrepPosition,
-}
-
-impl AstGrepRange {
-    pub fn contains_position(&self, pos: &AstGrepPosition) -> bool {
-        self.start.line <= pos.line
-            && self.end.line >= pos.line
-            && (self.start.line != pos.line || self.start.column <= pos.column)
-            && (self.end.line != pos.line || self.end.column >= pos.column)
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -114,24 +130,6 @@ pub struct MetaVariable {
 pub struct Label {
     pub text: String,
     pub range: AstGrepRange,
-}
-
-impl From<&lsp_types::LocationLink> for AstGrepPosition {
-    fn from(loc: &lsp_types::LocationLink) -> Self {
-        Self {
-            line: loc.target_range.start.line,
-            column: loc.target_range.start.character,
-        }
-    }
-}
-
-impl From<&lsp_types::Location> for AstGrepPosition {
-    fn from(loc: &lsp_types::Location) -> Self {
-        Self {
-            line: loc.range.start.line,
-            column: loc.range.start.character,
-        }
-    }
 }
 
 impl From<&AstGrepMatch> for lsp_types::Position {

--- a/lsproxy/src/lsp/manager/manager.rs
+++ b/lsproxy/src/lsp/manager/manager.rs
@@ -1,6 +1,6 @@
 use crate::api_types::{get_mount_dir, Identifier, SupportedLanguages, Symbol};
 use crate::ast_grep::client::AstGrepClient;
-use crate::ast_grep::types::{AstGrepMatch, AstGrepPosition};
+use crate::ast_grep::types::AstGrepMatch;
 use crate::lsp::client::LspClient;
 use crate::lsp::languages::{
     ClangdClient, GoplsClient, JdtlsClient, JediClient, PhpactorClient, RustAnalyzerClient,
@@ -349,8 +349,7 @@ impl Manager {
             let has_external_definitions = match &definition {
                 GotoDefinitionResponse::Scalar(loc) => {
                     let is_external = !original_symbol_match
-                        .get_context_range()
-                        .contains_position(&AstGrepPosition::from(loc));
+                        .contains_location(loc);
                     if !is_external {
                         // Check if internal symbol is a function
                         if let Ok(internal_symbol_match) = self
@@ -377,8 +376,7 @@ impl Manager {
                     let mut is_external_or_function = false;
                     for loc in locs {
                         let is_external = !original_symbol_match
-                            .get_context_range()
-                            .contains_position(&AstGrepPosition::from(loc));
+                            .contains_location(loc);
                         if is_external {
                             is_external_or_function = true;
                             break;
@@ -409,8 +407,7 @@ impl Manager {
                     let mut is_external_or_function = false;
                     for link in links {
                         let is_external = !original_symbol_match
-                            .get_context_range()
-                            .contains_position(&AstGrepPosition::from(link));
+                            .contains_locationlink(link);
                         if is_external {
                             is_external_or_function = true;
                             break;


### PR DESCRIPTION
## **Description**
- Introduced new methods `contains`, `contains_location`, and `contains_locationlink` in `AstGrepMatch` to improve location checking and containment logic.
- Replaced the `contains_position` method with more specific containment methods, simplifying the logic in `AstGrepClient` and `Manager`.
- Removed unnecessary conversion implementations for `AstGrepPosition`, streamlining the code.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.rs</strong><dd><code>Use `contains` method for reference filtering in AstGrepClient</code>&nbsp; </dd></summary>
<hr>

lsproxy/src/ast_grep/client.rs
<li>Replaced position matching logic with a new <code>contains</code> method.<br> <li> Simplified the filtering logic for contained references.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/115/files#diff-ae8ea3caace120b933d6d5b09de5c7a1fe231fd6591a961fbfa03dfcf3829b6a">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.rs</strong><dd><code>Add containment methods and remove obsolete conversions in <br>AstGrepMatch</code></dd></summary>
<hr>

lsproxy/src/ast_grep/types.rs
<li>Added <code>contains</code>, <code>contains_location</code>, and <code>contains_locationlink</code> methods.<br> <li> Removed <code>contains_position</code> method from <code>AstGrepRange</code>.<br> <li> Removed conversion implementations for <code>AstGrepPosition</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/115/files#diff-b9bc6bb404cf1647920e29f38dc9f874dc3529c140ed4ec6740edbb2cbf0c846">+25/-27</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manager.rs</strong><dd><code>Update location checking logic in Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/manager/manager.rs
<li>Replaced <code>contains_position</code> with <code>contains_location</code> and <br><code>contains_locationlink</code>.<br> <li> Updated logic for checking external definitions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/115/files#diff-a7e54653c95d12032a23bfeea27cdf48298307abf0def08c003e7acf29baa446">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
