### PR TITLE
Make Range optional in read source code endpoint

### DIFF
--- a/lsproxy/Cargo.toml
+++ b/lsproxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsproxy"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/lsproxy/src/ast_grep/types.rs
+++ b/lsproxy/src/ast_grep/types.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    api_types::{FilePosition, FileRange, Identifier, Position, Symbol},
+    api_types::{FilePosition, FileRange, Identifier, Position, Range, Symbol},
     utils::file_utils::absolute_path_to_relative_path_string,
 };
 
@@ -141,15 +141,17 @@ impl From<AstGrepMatch> for Symbol {
                     character: ast_match.range.start.column as u32,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: path.clone(),
-                start: Position {
-                    line: match_range.start.line as u32,
-                    character: 0, // TODO: this is not technically true, we're returning the whole line for consistency
-                },
-                end: Position {
-                    line: match_range.end.line as u32,
-                    character: match_range.end.column as u32,
+                range: Range {
+                    start: Position {
+                        line: match_range.start.line as u32,
+                        character: 0, // TODO: this is not technically true, we're returning the whole line for consistency
+                    },
+                    end: Position {
+                        line: match_range.end.line as u32,
+                        character: match_range.end.column as u32,
+                    },
                 },
             },
         }
@@ -168,15 +170,17 @@ impl From<AstGrepMatch> for Identifier {
         Identifier {
             name: ast_match.meta_variables.single.name.text.clone(),
             kind,
-            range: FileRange {
+            file_range: FileRange {
                 path: path.clone(),
-                start: Position {
-                    line: match_range.start.line as u32,
-                    character: match_range.start.column as u32,
-                },
-                end: Position {
-                    line: match_range.end.line as u32,
-                    character: match_range.end.column as u32,
+                range: Range {
+                    start: Position {
+                        line: match_range.start.line as u32,
+                        character: match_range.start.column as u32,
+                    },
+                    end: Position {
+                        line: match_range.end.line as u32,
+                        character: match_range.end.column as u32,
+                    },
                 },
             },
         }

--- a/lsproxy/src/handlers/definitions_in_file.rs
+++ b/lsproxy/src/handlers/definitions_in_file.rs
@@ -66,7 +66,7 @@ mod test {
 
     use actix_web::http::StatusCode;
 
-    use crate::api_types::{FilePosition, FileRange, Position, Symbol};
+    use crate::api_types::{FilePosition, FileRange, Position, Range, Symbol};
     use crate::initialize_app_state;
     use crate::test_utils::{python_sample_path, TestContext};
 
@@ -103,15 +103,17 @@ mod test {
                         character: 4,
                     },
                 },
-                range: FileRange {
+                file_range: FileRange {
                     path: String::from("main.py"),
-                    start: Position {
-                        line: 5,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: 12,
-                        character: 14,
+                    range: Range {
+                        start: Position {
+                            line: 5,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 12,
+                            character: 14,
+                        },
                     },
                 },
             },
@@ -125,15 +127,17 @@ mod test {
                         character: 4,
                     },
                 },
-                range: FileRange {
+                file_range: FileRange {
                     path: String::from("main.py"),
-                    start: Position {
-                        line: 14,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: 19,
-                        character: 28,
+                    range: Range {
+                        start: Position {
+                            line: 14,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 19,
+                            character: 28,
+                        },
                     },
                 },
             },

--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -318,7 +318,7 @@ mod test {
 
         assert_eq!(
             error_response.error,
-            "Failed to find definition from position: No identifier found at position. Closest matches: [Identifier { name: \"plt\", range: FileRange { path: \"main.py\", start: Position { line: 0, character: 28 }, end: Position { line: 0, character: 31 } }, kind: None }, Identifier { name: \"pyplot\", range: FileRange { path: \"main.py\", start: Position { line: 0, character: 18 }, end: Position { line: 0, character: 24 } }, kind: None }, Identifier { name: \"matplotlib\", range: FileRange { path: \"main.py\", start: Position { line: 0, character: 7 }, end: Position { line: 0, character: 17 } }, kind: None }]"
+            "Failed to find definition from position: No identifier found at position. Closest matches: [Identifier { name: \"plt\", file_range: FileRange { path: \"main.py\", range: Range { start: Position { line: 0, character: 28 }, end: Position { line: 0, character: 31 } } }, kind: None }, Identifier { name: \"pyplot\", file_range: FileRange { path: \"main.py\", range: Range { start: Position { line: 0, character: 18 }, end: Position { line: 0, character: 24 } } }, kind: None }, Identifier { name: \"matplotlib\", file_range: FileRange { path: \"main.py\", range: Range { start: Position { line: 0, character: 7 }, end: Position { line: 0, character: 17 } } }, kind: None }]"
         );
         Ok(())
     }

--- a/lsproxy/src/handlers/find_definition.rs
+++ b/lsproxy/src/handlers/find_definition.rs
@@ -1,4 +1,4 @@
-use crate::api_types::{CodeContext, ErrorResponse, FileRange, Position};
+use crate::api_types::{CodeContext, ErrorResponse, FileRange, Position, Range};
 use crate::handlers::error::IntoHttpResponse;
 use crate::handlers::utils;
 use crate::lsp::manager::{LspManagerError, Manager};
@@ -9,7 +9,7 @@ use log::{error, info, warn};
 
 use crate::api_types::{DefinitionResponse, GetDefinitionRequest};
 use crate::AppState;
-use lsp_types::{GotoDefinitionResponse, Location, Position as LspPosition, Range};
+use lsp_types::{GotoDefinitionResponse, Location, Position as LspPosition, Range as LspRange};
 /// Get the definition of a symbol at a specific position in a file
 ///
 /// Returns the location of the definition for the symbol at the given position.
@@ -142,13 +142,15 @@ async fn fetch_definition_source_code(
             Some(ast_grep_match) => CodeContext {
                 range: FileRange {
                     path: relative_path,
-                    start: Position {
-                        line: ast_grep_match.get_context_range().start.line as u32,
-                        character: ast_grep_match.get_context_range().start.column as u32,
-                    },
-                    end: Position {
-                        line: ast_grep_match.get_context_range().end.line as u32,
-                        character: ast_grep_match.get_context_range().end.column as u32,
+                    range: Range {
+                        start: Position {
+                            line: ast_grep_match.get_context_range().start.line as u32,
+                            character: ast_grep_match.get_context_range().start.column as u32,
+                        },
+                        end: Position {
+                            line: ast_grep_match.get_context_range().end.line as u32,
+                            character: ast_grep_match.get_context_range().end.column as u32,
+                        },
                     },
                 },
                 source_code: ast_grep_match.get_source_code(),
@@ -156,7 +158,7 @@ async fn fetch_definition_source_code(
             None => {
                 warn!("Symbol not found for definition: {:?}", definition);
                 warn!("No exact match in file symbols (likely filtered out). Returning an approximate range instead.");
-                let range = Range {
+                let range = LspRange {
                     start: LspPosition {
                         line: definition.range.start.line.saturating_sub(3),
                         character: 0,
@@ -172,13 +174,15 @@ async fn fetch_definition_source_code(
                 CodeContext {
                     range: FileRange {
                         path: relative_path,
-                        start: Position {
-                            line: definition.range.start.line.saturating_sub(3),
-                            character: 0,
-                        },
-                        end: Position {
-                            line: definition.range.end.line as u32 + 3,
-                            character: 0,
+                        range: Range {
+                            start: Position {
+                                line: definition.range.start.line.saturating_sub(3),
+                                character: 0,
+                            },
+                            end: Position {
+                                line: definition.range.end.line as u32 + 3,
+                                character: 0,
+                            },
                         },
                     },
                     source_code,
@@ -235,7 +239,49 @@ mod test {
         let bytes = actix_web::body::to_bytes(body).await.unwrap();
         let definition_response: DefinitionResponse = serde_json::from_slice(&bytes).unwrap();
 
-        let expected_response = DefinitionResponse { raw_response: None, definitions: vec![FilePosition { path: String::from("graph.py"), position: Position { line: 12, character: 6 } }], source_code_context: Some(vec![CodeContext { range: FileRange { path: String::from("graph.py"), start: Position { line: 12, character: 0 }, end: Position { line: 88, character: 16 } }, source_code: String::from("class AStarGraph(GraphBase):\n    def __init__(self):\n        self._barriers: List[List[Tuple[int, int]]] = []\n        self._barriers.append([\n            (2, 4), (2, 5), (2, 6),\n            (3, 6), (4, 6), (5, 6),\n            (5, 5), (5, 4), (5, 3),\n            (5, 2), (4, 2), (3, 2),\n        ])\n\n    @property\n    def barriers(self):\n        return self._barriers\n\n    def _barrier_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Original barrier-based cost calculation\"\"\"\n        for barrier in self.barriers:\n            if b in barrier:\n                return 100\n        return 1\n\n    def _distance_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Cost based on Manhattan distance between points\"\"\"\n        return abs(b[0] - a[0]) + abs(b[1] - a[1])\n\n    def _combined_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Combines barrier and distance costs\"\"\"\n        barrier_cost = self._barrier_cost(a, b)\n        distance_cost = self._distance_cost(a, b)\n        return barrier_cost * distance_cost\n\n    def move_cost(self, a: Tuple[int, int], b: Tuple[int, int], \n                 strategy: CostStrategy = CostStrategy.BARRIER) -> float:\n        \"\"\"\n        Calculate movement cost between two points using specified strategy.\n        \n        Args:\n            a: Starting position\n            b: Ending position\n            strategy: Cost calculation strategy to use\n            \n        Returns:\n            float: Cost of movement\n        \"\"\"\n        if strategy == CostStrategy.BARRIER:\n            cost_function = self._barrier_cost\n        elif strategy == CostStrategy.DISTANCE:\n            cost_function = self._distance_cost\n        elif strategy == CostStrategy.COMBINED:\n            cost_function = self._combined_cost\n        else:\n            raise ValueError(f\"Unknown cost strategy: {strategy}\")\n        \n        return cost_function(a, b)\n\n    @log_execution_time\n    def heuristic(self, start, goal):\n        D = 1\n        D2 = 1\n        dx = abs(start[0] - goal[0])\n        dy = abs(start[1] - goal[1])\n        return D * (dx + dy) + (D2 - 2 * D) * min(dx, dy)\n\n    @log_execution_time\n    def get_vertex_neighbours(self, pos, cost_strategy: CostStrategy = CostStrategy.BARRIER):\n        n = []\n        for dx, dy in [\n            (1, 0), (-1, 0), (0, 1), (0, -1),\n            (1, 1), (-1, 1), (1, -1), (-1, -1),\n        ]:\n            x2 = pos[0] + dx\n            y2 = pos[1] + dy\n            if x2 < 0 or x2 > 7 or y2 < 0 or y2 > 7:\n                continue\n            if self.move_cost(pos, (x2, y2), strategy=cost_strategy) < 100:\n                n.append((x2, y2))\n        return n") }]), selected_identifier: Identifier { name: String::from("AStarGraph"), kind: None, range: FileRange { path: String::from("main.py"), start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 28 } } } };
+        let expected_response = DefinitionResponse {
+            raw_response: None,
+            definitions: vec![FilePosition {
+                path: String::from("graph.py"),
+                position: Position {
+                    line: 12,
+                    character: 6,
+                },
+            }],
+            source_code_context: Some(vec![CodeContext {
+                range: FileRange {
+                    path: String::from("graph.py"),
+                    range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 88,
+                            character: 16,
+                        },
+                    },
+                },
+                source_code: String::from("class AStarGraph(GraphBase):\n    def __init__(self):\n        self._barriers: List[List[Tuple[int, int]]] = []\n        self._barriers.append([\n            (2, 4), (2, 5), (2, 6),\n            (3, 6), (4, 6), (5, 6),\n            (5, 5), (5, 4), (5, 3),\n            (5, 2), (4, 2), (3, 2),\n        ])\n\n    @property\n    def barriers(self):\n        return self._barriers\n\n    def _barrier_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Original barrier-based cost calculation\"\"\"\n        for barrier in self.barriers:\n            if b in barrier:\n                return 100\n        return 1\n\n    def _distance_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Cost based on Manhattan distance between points\"\"\"\n        return abs(b[0] - a[0]) + abs(b[1] - a[1])\n\n    def _combined_cost(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:\n        \"\"\"Combines barrier and distance costs\"\"\"\n        barrier_cost = self._barrier_cost(a, b)\n        distance_cost = self._distance_cost(a, b)\n        return barrier_cost * distance_cost\n\n    def move_cost(self, a: Tuple[int, int], b: Tuple[int, int], \n                 strategy: CostStrategy = CostStrategy.BARRIER) -> float:\n        \"\"\"\n        Calculate movement cost between two points using specified strategy.\n        \n        Args:\n            a: Starting position\n            b: Ending position\n            strategy: Cost calculation strategy to use\n            \n        Returns:\n            float: Cost of movement\n        \"\"\"\n        if strategy == CostStrategy.BARRIER:\n            cost_function = self._barrier_cost\n        elif strategy == CostStrategy.DISTANCE:\n            cost_function = self._distance_cost\n        elif strategy == CostStrategy.COMBINED:\n            cost_function = self._combined_cost\n        else:\n            raise ValueError(f\"Unknown cost strategy: {strategy}\")\n        \n        return cost_function(a, b)\n\n    @log_execution_time\n    def heuristic(self, start, goal):\n        D = 1\n        D2 = 1\n        dx = abs(start[0] - goal[0])\n        dy = abs(start[1] - goal[1])\n        return D * (dx + dy) + (D2 - 2 * D) * min(dx, dy)\n\n    @log_execution_time\n    def get_vertex_neighbours(self, pos, cost_strategy: CostStrategy = CostStrategy.BARRIER):\n        n = []\n        for dx, dy in [\n            (1, 0), (-1, 0), (0, 1), (0, -1),\n            (1, 1), (-1, 1), (1, -1), (-1, -1),\n        ]:\n            x2 = pos[0] + dx\n            y2 = pos[1] + dy\n            if x2 < 0 or x2 > 7 or y2 < 0 or y2 > 7:\n                continue\n            if self.move_cost(pos, (x2, y2), strategy=cost_strategy) < 100:\n                n.append((x2, y2))\n        return n"),
+            }]),
+            selected_identifier: Identifier {
+                name: String::from("AStarGraph"),
+                kind: None,
+                file_range: FileRange {
+                    path: String::from("main.py"),
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 18,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 28,
+                        },
+                    },
+                },
+            },
+        };
 
         assert_eq!(definition_response, expected_response);
         Ok(())

--- a/lsproxy/src/handlers/find_identifier.rs
+++ b/lsproxy/src/handlers/find_identifier.rs
@@ -155,7 +155,14 @@ mod test {
 
         assert_eq!(identifier_response.identifiers.len(), 1);
         assert_eq!(identifier_response.identifiers[0].name, "AStarGraph");
-        assert_eq!(identifier_response.identifiers[0].range.start.line, 12);
+        assert_eq!(
+            identifier_response.identifiers[0]
+                .file_range
+                .range
+                .start
+                .line,
+            12
+        );
         Ok(())
     }
 

--- a/lsproxy/src/handlers/find_referenced_symbols.rs
+++ b/lsproxy/src/handlers/find_referenced_symbols.rs
@@ -807,7 +807,7 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("log_execution_time"),
-                        kind: Some(String::from("function-call")),
+                        kind: Some(String::from("decorator")),
                         file_range: FileRange {
                             path: String::from("search.py"),
                             range: Range {
@@ -1623,103 +1623,137 @@ mod test {
                     },
                 },
                 Identifier {
+                    name: String::from("property"),
+                    kind: Some(String::from("decorator")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 22,
+                                character: 5,
+                            },
+                            end: Position {
+                                line: 22,
+                                character: 13,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("abs"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 35,
+                                character: 15,
+                            },
+                            end: Position {
+                                line: 35,
+                                character: 18,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("abs"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 35,
+                                character: 34,
+                            },
+                            end: Position {
+                                line: 35,
+                                character: 37,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("ValueError"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 63,
+                                character: 18,
+                            },
+                            end: Position {
+                                line: 63,
+                                character: 28,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("abs"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 71,
+                                character: 13,
+                            },
+                            end: Position {
+                                line: 71,
+                                character: 16,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("abs"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 72,
+                                character: 13,
+                            },
+                            end: Position {
+                                line: 72,
+                                character: 16,
+                            },
+                        },
+                    },
+                },
+                Identifier {
                     name: String::from("min"),
                     kind: Some(String::from("function-call")),
                     file_range: FileRange {
                         path: String::from("graph.py"),
                         range: Range {
                             start: Position {
-                                line: 15,
-                                character: 23,
+                                line: 73,
+                                character: 46,
                             },
                             end: Position {
-                                line: 15,
-                                character: 29,
+                                line: 73,
+                                character: 49,
                             },
                         },
                     },
                 },
                 Identifier {
-                    name: String::from("remove"),
+                    name: String::from("append"),
                     kind: Some(String::from("function-call")),
                     file_range: FileRange {
                         path: String::from("graph.py"),
                         range: Range {
                             start: Position {
-                                line: 15,
-                                character: 23,
+                                line: 87,
+                                character: 18,
                             },
                             end: Position {
-                                line: 15,
-                                character: 29,
-                            },
-                        },
-                    },
-                },
-                Identifier {
-                    name: String::from("add"),
-                    kind: Some(String::from("function-call")),
-                    file_range: FileRange {
-                        path: String::from("graph.py"),
-                        range: Range {
-                            start: Position {
-                                line: 15,
-                                character: 23,
-                            },
-                            end: Position {
-                                line: 15,
-                                character: 29,
-                            },
-                        },
-                    },
-                },
-                Identifier {
-                    name: String::from("get"),
-                    kind: Some(String::from("function-call")),
-                    file_range: FileRange {
-                        path: String::from("graph.py"),
-                        range: Range {
-                            start: Position {
-                                line: 15,
-                                character: 23,
-                            },
-                            end: Position {
-                                line: 15,
-                                character: 29,
-                            },
-                        },
-                    },
-                },
-                Identifier {
-                    name: String::from("float"),
-                    kind: Some(String::from("function-call")),
-                    file_range: FileRange {
-                        path: String::from("graph.py"),
-                        range: Range {
-                            start: Position {
-                                line: 15,
-                                character: 23,
-                            },
-                            end: Position {
-                                line: 15,
-                                character: 29,
-                            },
-                        },
-                    },
-                },
-                Identifier {
-                    name: String::from("RuntimeError"),
-                    kind: Some(String::from("function-call")),
-                    file_range: FileRange {
-                        path: String::from("graph.py"),
-                        range: Range {
-                            start: Position {
-                                line: 15,
-                                character: 23,
-                            },
-                            end: Position {
-                                line: 15,
-                                character: 29,
+                                line: 87,
+                                character: 24,
                             },
                         },
                     },

--- a/lsproxy/src/handlers/find_referenced_symbols.rs
+++ b/lsproxy/src/handlers/find_referenced_symbols.rs
@@ -166,13 +166,18 @@ pub async fn find_referenced_symbols(
 
     // Sort workspace_symbols by reference location
     workspace_symbols.sort_by(|a, b| {
-        let path_cmp = a.reference.range.path.cmp(&b.reference.range.path);
+        let path_cmp = a
+            .reference
+            .file_range
+            .path
+            .cmp(&b.reference.file_range.path);
         if path_cmp.is_eq() {
             a.reference
+                .file_range
                 .range
                 .start
                 .line
-                .cmp(&b.reference.range.start.line)
+                .cmp(&b.reference.file_range.range.start.line)
         } else {
             path_cmp
         }
@@ -180,9 +185,13 @@ pub async fn find_referenced_symbols(
 
     // Sort external_symbols by location
     external_symbols.sort_by(|a, b| {
-        let path_cmp = a.range.path.cmp(&b.range.path);
+        let path_cmp = a.file_range.path.cmp(&b.file_range.path);
         if path_cmp.is_eq() {
-            a.range.start.line.cmp(&b.range.start.line)
+            a.file_range
+                .range
+                .start
+                .line
+                .cmp(&b.file_range.range.start.line)
         } else {
             path_cmp
         }
@@ -190,9 +199,13 @@ pub async fn find_referenced_symbols(
 
     // Sort not_found by location
     not_found.sort_by(|a, b| {
-        let path_cmp = a.range.path.cmp(&b.range.path);
+        let path_cmp = a.file_range.path.cmp(&b.file_range.path);
         if path_cmp.is_eq() {
-            a.range.start.line.cmp(&b.range.start.line)
+            a.file_range
+                .range
+                .start
+                .line
+                .cmp(&b.file_range.range.start.line)
         } else {
             path_cmp
         }
@@ -213,7 +226,7 @@ mod test {
     use actix_web::http::StatusCode;
     use tokio::time::{sleep, Duration};
 
-    use crate::api_types::{FilePosition, FileRange, Position, Symbol};
+    use crate::api_types::{FilePosition, FileRange, Position, Range, Symbol};
     use crate::initialize_app_state;
     use crate::test_utils::{csharp_sample_path, python_sample_path, TestContext};
 
@@ -260,18 +273,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("AddNeighborsToOpenList"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 28,
-                                character: 12,
-                            },
-                            end: Position {
-                                line: 28,
-                                character: 34,
+                            range: Range {
+                                start: Position {
+                                    line: 28,
+                                    character: 12,
+                                },
+                                end: Position {
+                                    line: 28,
+                                    character: 34,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("AddNeighborsToOpenList"),
@@ -283,15 +298,17 @@ mod test {
                                 character: 21,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 51,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 76,
-                                character: 9,
+                            range: Range {
+                                start: Position {
+                                    line: 51,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 76,
+                                    character: 9,
+                                },
                             },
                         },
                     }],
@@ -299,18 +316,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("AddNeighborsToOpenList"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 38,
-                                character: 16,
-                            },
-                            end: Position {
-                                line: 38,
-                                character: 38,
+                            range: Range {
+                                start: Position {
+                                    line: 38,
+                                    character: 16,
+                                },
+                                end: Position {
+                                    line: 38,
+                                    character: 38,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("AddNeighborsToOpenList"),
@@ -322,15 +341,17 @@ mod test {
                                 character: 21,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 51,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 76,
-                                character: 9,
+                            range: Range {
+                                start: Position {
+                                    line: 51,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 76,
+                                    character: 9,
+                                },
                             },
                         },
                     }],
@@ -338,18 +359,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("Distance"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 60,
-                                character: 94,
-                            },
-                            end: Position {
-                                line: 60,
-                                character: 102,
+                            range: Range {
+                                start: Position {
+                                    line: 60,
+                                    character: 94,
+                                },
+                                end: Position {
+                                    line: 60,
+                                    character: 102,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("Distance"),
@@ -361,15 +384,17 @@ mod test {
                                 character: 23,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 78,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 81,
-                                character: 9,
+                            range: Range {
+                                start: Position {
+                                    line: 78,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 81,
+                                    character: 9,
+                                },
                             },
                         },
                     }],
@@ -377,18 +402,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("FindNeighborInList"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 66,
-                                character: 25,
-                            },
-                            end: Position {
-                                line: 66,
-                                character: 43,
+                            range: Range {
+                                start: Position {
+                                    line: 66,
+                                    character: 25,
+                                },
+                                end: Position {
+                                    line: 66,
+                                    character: 43,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("FindNeighborInList"),
@@ -400,15 +427,17 @@ mod test {
                                 character: 21,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 83,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 86,
-                                character: 9,
+                            range: Range {
+                                start: Position {
+                                    line: 83,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 86,
+                                    character: 9,
+                                },
                             },
                         },
                     }],
@@ -416,18 +445,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("FindNeighborInList"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 67,
-                                character: 25,
-                            },
-                            end: Position {
-                                line: 67,
-                                character: 43,
+                            range: Range {
+                                start: Position {
+                                    line: 67,
+                                    character: 25,
+                                },
+                                end: Position {
+                                    line: 67,
+                                    character: 43,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("FindNeighborInList"),
@@ -439,15 +470,17 @@ mod test {
                                 character: 21,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("AStar.cs"),
-                            start: Position {
-                                line: 83,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 86,
-                                character: 9,
+                            range: Range {
+                                start: Position {
+                                    line: 83,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 86,
+                                    character: 9,
+                                },
                             },
                         },
                     }],
@@ -456,215 +489,243 @@ mod test {
             external_symbols: vec![
                 Identifier {
                     name: String::from("Add"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 27,
-                            character: 20,
-                        },
-                        end: Position {
-                            line: 27,
-                            character: 23,
+                        range: Range {
+                            start: Position {
+                                line: 27,
+                                character: 20,
+                            },
+                            end: Position {
+                                line: 27,
+                                character: 23,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Any"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 32,
-                            character: 27,
-                        },
-                        end: Position {
-                            line: 32,
-                            character: 30,
+                        range: Range {
+                            start: Position {
+                                line: 32,
+                                character: 27,
+                            },
+                            end: Position {
+                                line: 32,
+                                character: 30,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("RemoveAt"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 36,
-                            character: 22,
-                        },
-                        end: Position {
-                            line: 36,
-                            character: 30,
+                        range: Range {
+                            start: Position {
+                                line: 36,
+                                character: 22,
+                            },
+                            end: Position {
+                                line: 36,
+                                character: 30,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Add"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 37,
-                            character: 24,
-                        },
-                        end: Position {
-                            line: 37,
-                            character: 27,
+                        range: Range {
+                            start: Position {
+                                line: 37,
+                                character: 24,
+                            },
+                            end: Position {
+                                line: 37,
+                                character: 27,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Insert"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 41,
-                            character: 18,
-                        },
-                        end: Position {
-                            line: 41,
-                            character: 24,
+                        range: Range {
+                            start: Position {
+                                line: 41,
+                                character: 18,
+                            },
+                            end: Position {
+                                line: 41,
+                                character: 24,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Insert"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 45,
-                            character: 22,
-                        },
-                        end: Position {
-                            line: 45,
-                            character: 28,
+                        range: Range {
+                            start: Position {
+                                line: 45,
+                                character: 22,
+                            },
+                            end: Position {
+                                line: 45,
+                                character: 28,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Add"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 71,
-                            character: 30,
-                        },
-                        end: Position {
-                            line: 71,
-                            character: 33,
+                        range: Range {
+                            start: Position {
+                                line: 71,
+                                character: 30,
+                            },
+                            end: Position {
+                                line: 71,
+                                character: 33,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Sort"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 75,
-                            character: 18,
-                        },
-                        end: Position {
-                            line: 75,
-                            character: 22,
+                        range: Range {
+                            start: Position {
+                                line: 75,
+                                character: 18,
+                            },
+                            end: Position {
+                                line: 75,
+                                character: 22,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Sqrt"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 80,
-                            character: 24,
-                        },
-                        end: Position {
-                            line: 80,
-                            character: 28,
+                        range: Range {
+                            start: Position {
+                                line: 80,
+                                character: 24,
+                            },
+                            end: Position {
+                                line: 80,
+                                character: 28,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Pow"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 80,
-                            character: 34,
-                        },
-                        end: Position {
-                            line: 80,
-                            character: 37,
+                        range: Range {
+                            start: Position {
+                                line: 80,
+                                character: 34,
+                            },
+                            end: Position {
+                                line: 80,
+                                character: 37,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Pow"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 80,
-                            character: 74,
-                        },
-                        end: Position {
-                            line: 80,
-                            character: 77,
+                        range: Range {
+                            start: Position {
+                                line: 80,
+                                character: 74,
+                            },
+                            end: Position {
+                                line: 80,
+                                character: 77,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("Any"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 85,
-                            character: 24,
-                        },
-                        end: Position {
-                            line: 85,
-                            character: 27,
+                        range: Range {
+                            start: Position {
+                                line: 85,
+                                character: 24,
+                            },
+                            end: Position {
+                                line: 85,
+                                character: 27,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
             ],
             not_found: vec![
                 Identifier {
                     name: String::from("Node"),
-                    range: FileRange {
+                    kind: Some(String::from("class")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 17,
-                            character: 27,
-                        },
-                        end: Position {
-                            line: 17,
-                            character: 31,
+                        range: Range {
+                            start: Position {
+                                line: 17,
+                                character: 27,
+                            },
+                            end: Position {
+                                line: 17,
+                                character: 31,
+                            },
                         },
                     },
-                    kind: Some(String::from("class-instantiation")),
                 },
                 Identifier {
                     name: String::from("Node"),
-                    range: FileRange {
+                    kind: Some(String::from("class")),
+                    file_range: FileRange {
                         path: String::from("AStar.cs"),
-                        start: Position {
-                            line: 60,
-                            character: 35,
-                        },
-                        end: Position {
-                            line: 60,
-                            character: 39,
+                        range: Range {
+                            start: Position {
+                                line: 60,
+                                character: 35,
+                            },
+                            end: Position {
+                                line: 60,
+                                character: 39,
+                            },
                         },
                     },
-                    kind: Some(String::from("class-instantiation")),
                 },
             ],
         };
@@ -746,18 +807,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("log_execution_time"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 15,
-                                character: 1,
-                            },
-                            end: Position {
-                                line: 15,
-                                character: 19,
+                            range: Range {
+                                start: Position {
+                                    line: 15,
+                                    character: 1,
+                                },
+                                end: Position {
+                                    line: 15,
+                                    character: 19,
+                                },
                             },
                         },
-                        kind: Some(String::from("decorator")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("log_execution_time"),
@@ -769,15 +832,17 @@ mod test {
                                 character: 4,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("decorators.py"),
-                            start: Position {
-                                line: 3,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 11,
-                                character: 18,
+                            range: Range {
+                                start: Position {
+                                    line: 3,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 11,
+                                    character: 18,
+                                },
                             },
                         },
                     }],
@@ -785,18 +850,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("initialize_search"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 29,
-                                character: 54,
-                            },
-                            end: Position {
-                                line: 29,
-                                character: 71,
+                            range: Range {
+                                start: Position {
+                                    line: 29,
+                                    character: 54,
+                                },
+                                end: Position {
+                                    line: 29,
+                                    character: 71,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("initialize_search"),
@@ -808,15 +875,17 @@ mod test {
                                 character: 4,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 4,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 13,
-                                character: 58,
+                            range: Range {
+                                start: Position {
+                                    line: 4,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 13,
+                                    character: 58,
+                                },
                             },
                         },
                     }],
@@ -824,18 +893,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("reconstruct_path"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 36,
-                                character: 19,
-                            },
-                            end: Position {
-                                line: 36,
-                                character: 35,
+                            range: Range {
+                                start: Position {
+                                    line: 36,
+                                    character: 19,
+                                },
+                                end: Position {
+                                    line: 36,
+                                    character: 35,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("reconstruct_path"),
@@ -847,15 +918,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 17,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 27,
-                                character: 25,
+                            range: Range {
+                                start: Position {
+                                    line: 17,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 27,
+                                    character: 25,
+                                },
                             },
                         },
                     }],
@@ -863,18 +936,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("get_vertex_neighbours"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 41,
-                                character: 31,
-                            },
-                            end: Position {
-                                line: 41,
-                                character: 52,
+                            range: Range {
+                                start: Position {
+                                    line: 41,
+                                    character: 31,
+                                },
+                                end: Position {
+                                    line: 41,
+                                    character: 52,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("get_vertex_neighbours"),
@@ -886,15 +961,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 75,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 88,
-                                character: 16,
+                            range: Range {
+                                start: Position {
+                                    line: 75,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 88,
+                                    character: 16,
+                                },
                             },
                         },
                     }],
@@ -902,18 +979,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("move_cost"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 45,
-                                character: 45,
-                            },
-                            end: Position {
-                                line: 45,
-                                character: 54,
+                            range: Range {
+                                start: Position {
+                                    line: 45,
+                                    character: 45,
+                                },
+                                end: Position {
+                                    line: 45,
+                                    character: 54,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("move_cost"),
@@ -925,15 +1004,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 43,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 65,
-                                character: 34,
+                            range: Range {
+                                start: Position {
+                                    line: 43,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 65,
+                                    character: 34,
+                                },
                             },
                         },
                     }],
@@ -941,18 +1022,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("heuristic"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("search.py"),
-                            start: Position {
-                                line: 54,
-                                character: 48,
-                            },
-                            end: Position {
-                                line: 54,
-                                character: 57,
+                            range: Range {
+                                start: Position {
+                                    line: 54,
+                                    character: 48,
+                                },
+                                end: Position {
+                                    line: 54,
+                                    character: 57,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("heuristic"),
@@ -964,15 +1047,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 67,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 73,
-                                character: 57,
+                            range: Range {
+                                start: Position {
+                                    line: 67,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 73,
+                                    character: 57,
+                                },
                             },
                         },
                     }],
@@ -981,138 +1066,156 @@ mod test {
             external_symbols: vec![
                 Identifier {
                     name: String::from("append"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 24,
-                            character: 17,
-                        },
-                        end: Position {
-                            line: 24,
-                            character: 23,
+                        range: Range {
+                            start: Position {
+                                line: 24,
+                                character: 17,
+                            },
+                            end: Position {
+                                line: 24,
+                                character: 23,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("append"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 26,
-                            character: 13,
-                        },
-                        end: Position {
-                            line: 26,
-                            character: 19,
+                        range: Range {
+                            start: Position {
+                                line: 26,
+                                character: 13,
+                            },
+                            end: Position {
+                                line: 26,
+                                character: 19,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("min"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 34,
-                            character: 18,
-                        },
-                        end: Position {
-                            line: 34,
-                            character: 21,
+                        range: Range {
+                            start: Position {
+                                line: 34,
+                                character: 18,
+                            },
+                            end: Position {
+                                line: 34,
+                                character: 21,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("remove"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 38,
-                            character: 22,
-                        },
-                        end: Position {
-                            line: 38,
-                            character: 28,
+                        range: Range {
+                            start: Position {
+                                line: 38,
+                                character: 22,
+                            },
+                            end: Position {
+                                line: 38,
+                                character: 28,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("add"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 39,
-                            character: 24,
-                        },
-                        end: Position {
-                            line: 39,
-                            character: 27,
+                        range: Range {
+                            start: Position {
+                                line: 39,
+                                character: 24,
+                            },
+                            end: Position {
+                                line: 39,
+                                character: 27,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("add"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 48,
-                            character: 30,
-                        },
-                        end: Position {
-                            line: 48,
-                            character: 33,
+                        range: Range {
+                            start: Position {
+                                line: 48,
+                                character: 30,
+                            },
+                            end: Position {
+                                line: 48,
+                                character: 33,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("get"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 49,
-                            character: 34,
-                        },
-                        end: Position {
-                            line: 49,
-                            character: 37,
+                        range: Range {
+                            start: Position {
+                                line: 49,
+                                character: 34,
+                            },
+                            end: Position {
+                                line: 49,
+                                character: 37,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("float"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 49,
-                            character: 49,
-                        },
-                        end: Position {
-                            line: 49,
-                            character: 54,
+                        range: Range {
+                            start: Position {
+                                line: 49,
+                                character: 49,
+                            },
+                            end: Position {
+                                line: 49,
+                                character: 54,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("RuntimeError"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("search.py"),
-                        start: Position {
-                            line: 56,
-                            character: 10,
-                        },
-                        end: Position {
-                            line: 56,
-                            character: 22,
+                        range: Range {
+                            start: Position {
+                                line: 56,
+                                character: 10,
+                            },
+                            end: Position {
+                                line: 56,
+                                character: 22,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
             ],
             not_found: vec![],
@@ -1195,18 +1298,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("_barrier_cost"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 39,
-                                character: 28,
-                            },
-                            end: Position {
-                                line: 39,
-                                character: 41,
+                            range: Range {
+                                start: Position {
+                                    line: 39,
+                                    character: 28,
+                                },
+                                end: Position {
+                                    line: 39,
+                                    character: 41,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("_barrier_cost"),
@@ -1218,15 +1323,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 26,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 31,
-                                character: 16,
+                            range: Range {
+                                start: Position {
+                                    line: 26,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 31,
+                                    character: 16,
+                                },
                             },
                         },
                     }],
@@ -1234,18 +1341,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("_distance_cost"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 40,
-                                character: 29,
-                            },
-                            end: Position {
-                                line: 40,
-                                character: 43,
+                            range: Range {
+                                start: Position {
+                                    line: 40,
+                                    character: 29,
+                                },
+                                end: Position {
+                                    line: 40,
+                                    character: 43,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("_distance_cost"),
@@ -1257,15 +1366,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 33,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 35,
-                                character: 50,
+                            range: Range {
+                                start: Position {
+                                    line: 33,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 35,
+                                    character: 50,
+                                },
                             },
                         },
                     }],
@@ -1273,18 +1384,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("cost_function"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 65,
-                                character: 15,
-                            },
-                            end: Position {
-                                line: 65,
-                                character: 28,
+                            range: Range {
+                                start: Position {
+                                    line: 65,
+                                    character: 15,
+                                },
+                                end: Position {
+                                    line: 65,
+                                    character: 28,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![
                         Symbol {
@@ -1297,15 +1410,17 @@ mod test {
                                     character: 12,
                                 },
                             },
-                            range: FileRange {
+                            file_range: FileRange {
                                 path: String::from("graph.py"),
-                                start: Position {
-                                    line: 59,
-                                    character: 0,
-                                },
-                                end: Position {
-                                    line: 59,
-                                    character: 47,
+                                range: Range {
+                                    start: Position {
+                                        line: 59,
+                                        character: 0,
+                                    },
+                                    end: Position {
+                                        line: 59,
+                                        character: 47,
+                                    },
                                 },
                             },
                         },
@@ -1319,15 +1434,17 @@ mod test {
                                     character: 12,
                                 },
                             },
-                            range: FileRange {
+                            file_range: FileRange {
                                 path: String::from("graph.py"),
-                                start: Position {
-                                    line: 61,
-                                    character: 0,
-                                },
-                                end: Position {
-                                    line: 61,
-                                    character: 47,
+                                range: Range {
+                                    start: Position {
+                                        line: 61,
+                                        character: 0,
+                                    },
+                                    end: Position {
+                                        line: 61,
+                                        character: 47,
+                                    },
                                 },
                             },
                         },
@@ -1341,15 +1458,17 @@ mod test {
                                     character: 12,
                                 },
                             },
-                            range: FileRange {
+                            file_range: FileRange {
                                 path: String::from("graph.py"),
-                                start: Position {
-                                    line: 57,
-                                    character: 0,
-                                },
-                                end: Position {
-                                    line: 57,
-                                    character: 46,
+                                range: Range {
+                                    start: Position {
+                                        line: 57,
+                                        character: 0,
+                                    },
+                                    end: Position {
+                                        line: 57,
+                                        character: 46,
+                                    },
                                 },
                             },
                         },
@@ -1358,18 +1477,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("log_execution_time"),
-                        range: FileRange {
+                        kind: Some(String::from("decorator")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 67,
-                                character: 5,
-                            },
-                            end: Position {
-                                line: 67,
-                                character: 23,
+                            range: Range {
+                                start: Position {
+                                    line: 67,
+                                    character: 5,
+                                },
+                                end: Position {
+                                    line: 67,
+                                    character: 23,
+                                },
                             },
                         },
-                        kind: Some(String::from("decorator")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("log_execution_time"),
@@ -1381,15 +1502,17 @@ mod test {
                                 character: 4,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("decorators.py"),
-                            start: Position {
-                                line: 3,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 11,
-                                character: 18,
+                            range: Range {
+                                start: Position {
+                                    line: 3,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 11,
+                                    character: 18,
+                                },
                             },
                         },
                     }],
@@ -1397,18 +1520,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("log_execution_time"),
-                        range: FileRange {
+                        kind: Some(String::from("decorator")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 75,
-                                character: 5,
-                            },
-                            end: Position {
-                                line: 75,
-                                character: 23,
+                            range: Range {
+                                start: Position {
+                                    line: 75,
+                                    character: 5,
+                                },
+                                end: Position {
+                                    line: 75,
+                                    character: 23,
+                                },
                             },
                         },
-                        kind: Some(String::from("decorator")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("log_execution_time"),
@@ -1420,15 +1545,17 @@ mod test {
                                 character: 4,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("decorators.py"),
-                            start: Position {
-                                line: 3,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 11,
-                                character: 18,
+                            range: Range {
+                                start: Position {
+                                    line: 3,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 11,
+                                    character: 18,
+                                },
                             },
                         },
                     }],
@@ -1436,18 +1563,20 @@ mod test {
                 ReferenceWithSymbolDefinitions {
                     reference: Identifier {
                         name: String::from("move_cost"),
-                        range: FileRange {
+                        kind: Some(String::from("function-call")),
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 86,
-                                character: 20,
-                            },
-                            end: Position {
-                                line: 86,
-                                character: 29,
+                            range: Range {
+                                start: Position {
+                                    line: 86,
+                                    character: 20,
+                                },
+                                end: Position {
+                                    line: 86,
+                                    character: 29,
+                                },
                             },
                         },
-                        kind: Some(String::from("function-call")),
                     },
                     definitions: vec![Symbol {
                         name: String::from("move_cost"),
@@ -1459,15 +1588,17 @@ mod test {
                                 character: 8,
                             },
                         },
-                        range: FileRange {
+                        file_range: FileRange {
                             path: String::from("graph.py"),
-                            start: Position {
-                                line: 43,
-                                character: 0,
-                            },
-                            end: Position {
-                                line: 65,
-                                character: 34,
+                            range: Range {
+                                start: Position {
+                                    line: 43,
+                                    character: 0,
+                                },
+                                end: Position {
+                                    line: 65,
+                                    character: 34,
+                                },
                             },
                         },
                     }],
@@ -1476,138 +1607,122 @@ mod test {
             external_symbols: vec![
                 Identifier {
                     name: String::from("append"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 15,
-                            character: 23,
-                        },
-                        end: Position {
-                            line: 15,
-                            character: 29,
-                        },
-                    },
                     kind: Some(String::from("function-call")),
-                },
-                Identifier {
-                    name: String::from("property"),
-                    range: FileRange {
+                    file_range: FileRange {
                         path: String::from("graph.py"),
-                        start: Position {
-                            line: 22,
-                            character: 5,
-                        },
-                        end: Position {
-                            line: 22,
-                            character: 13,
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
                         },
                     },
-                    kind: Some(String::from("decorator")),
-                },
-                Identifier {
-                    name: String::from("abs"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 35,
-                            character: 15,
-                        },
-                        end: Position {
-                            line: 35,
-                            character: 18,
-                        },
-                    },
-                    kind: Some(String::from("function-call")),
-                },
-                Identifier {
-                    name: String::from("abs"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 35,
-                            character: 34,
-                        },
-                        end: Position {
-                            line: 35,
-                            character: 37,
-                        },
-                    },
-                    kind: Some(String::from("function-call")),
-                },
-                Identifier {
-                    name: String::from("ValueError"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 63,
-                            character: 18,
-                        },
-                        end: Position {
-                            line: 63,
-                            character: 28,
-                        },
-                    },
-                    kind: Some(String::from("function-call")),
-                },
-                Identifier {
-                    name: String::from("abs"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 71,
-                            character: 13,
-                        },
-                        end: Position {
-                            line: 71,
-                            character: 16,
-                        },
-                    },
-                    kind: Some(String::from("function-call")),
-                },
-                Identifier {
-                    name: String::from("abs"),
-                    range: FileRange {
-                        path: String::from("graph.py"),
-                        start: Position {
-                            line: 72,
-                            character: 13,
-                        },
-                        end: Position {
-                            line: 72,
-                            character: 16,
-                        },
-                    },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
                     name: String::from("min"),
-                    range: FileRange {
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("graph.py"),
-                        start: Position {
-                            line: 73,
-                            character: 46,
-                        },
-                        end: Position {
-                            line: 73,
-                            character: 49,
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
                         },
                     },
-                    kind: Some(String::from("function-call")),
                 },
                 Identifier {
-                    name: String::from("append"),
-                    range: FileRange {
+                    name: String::from("remove"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
                         path: String::from("graph.py"),
-                        start: Position {
-                            line: 87,
-                            character: 18,
-                        },
-                        end: Position {
-                            line: 87,
-                            character: 24,
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
                         },
                     },
+                },
+                Identifier {
+                    name: String::from("add"),
                     kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("get"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("float"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
+                        },
+                    },
+                },
+                Identifier {
+                    name: String::from("RuntimeError"),
+                    kind: Some(String::from("function-call")),
+                    file_range: FileRange {
+                        path: String::from("graph.py"),
+                        range: Range {
+                            start: Position {
+                                line: 15,
+                                character: 23,
+                            },
+                            end: Position {
+                                line: 15,
+                                character: 29,
+                            },
+                        },
+                    },
                 },
             ],
             not_found: vec![],

--- a/lsproxy/src/handlers/find_references.rs
+++ b/lsproxy/src/handlers/find_references.rs
@@ -4,7 +4,7 @@ use log::{error, info};
 use lsp_types::{Location, Position as LspPosition};
 
 use crate::api_types::{
-    CodeContext, ErrorResponse, FilePosition, FileRange, GetReferencesRequest, Position,
+    CodeContext, ErrorResponse, FilePosition, FileRange, GetReferencesRequest, Position, Range,
     ReferencesResponse,
 };
 use crate::handlers::error::IntoHttpResponse;
@@ -208,13 +208,15 @@ async fn fetch_code_context(
                     source_code,
                     range: FileRange {
                         path: uri_to_relative_path_string(&reference.uri),
-                        start: Position {
-                            line: range.start.line,
-                            character: 0,
-                        },
-                        end: Position {
-                            line: range.end.line,
-                            character: 0,
+                        range: Range {
+                            start: Position {
+                                line: range.start.line,
+                                character: 0,
+                            },
+                            end: Position {
+                                line: range.end.line,
+                                character: 0,
+                            },
                         },
                     },
                 });
@@ -325,15 +327,17 @@ mod test {
             selected_identifier: Identifier {
                 name: String::from("AStarGraph"),
                 kind: None,
-                range: FileRange {
+                file_range: FileRange {
                     path: String::from("graph.py"),
-                    start: Position {
-                        line: 12,
-                        character: 6,
-                    },
-                    end: Position {
-                        line: 12,
-                        character: 16,
+                    range: Range {
+                        start: Position {
+                            line: 12,
+                            character: 6,
+                        },
+                        end: Position {
+                            line: 12,
+                            character: 16,
+                        },
                     },
                 },
             },
@@ -537,15 +541,17 @@ mod test {
             context: None,
             selected_identifier: Identifier {
                 name: String::from("log_time"),
-                range: FileRange {
+                file_range: FileRange {
                     path: String::from("decorators.rb"),
-                    start: Position {
-                        line: 8,
-                        character: 8,
-                    },
-                    end: Position {
-                        line: 8,
-                        character: 16,
+                    range: Range {
+                        start: Position {
+                            line: 8,
+                            character: 8,
+                        },
+                        end: Position {
+                            line: 8,
+                            character: 16,
+                        },
                     },
                 },
                 kind: None,

--- a/lsproxy/src/handlers/find_references.rs
+++ b/lsproxy/src/handlers/find_references.rs
@@ -587,8 +587,7 @@ mod test {
         let error_response: ErrorResponse = serde_json::from_slice(&bytes)?;
         assert_eq!(
             error_response.error,
-            "Failed to find references from position: No identifier found at position. Closest matches: [Identifier { name: \"n\", range: FileRange { path: \"graph.py\", start: Position { line: 88, character: 15 }, end: Position { line: 88, character: 16 } }, kind: None }, Identifier { name: \"n\", range: FileRange { path: \"graph.py\", start: Position { line: 87, character: 16 }, end: Position { line: 87, character: 17 } }, kind: None }, Identifier { name: \"append\", range: FileRange { path: \"graph.py\", start: Position { line: 87, character: 18 }, end: Position { line: 87, character: 24 } }, kind: None }]"
-        );
+            "Failed to find references from position: No identifier found at position. Closest matches: [Identifier { name: \"n\", file_range: FileRange { path: \"graph.py\", range: Range { start: Position { line: 88, character: 15 }, end: Position { line: 88, character: 16 } } }, kind: None }, Identifier { name: \"n\", file_range: FileRange { path: \"graph.py\", range: Range { start: Position { line: 87, character: 16 }, end: Position { line: 87, character: 17 } } }, kind: None }, Identifier { name: \"append\", file_range: FileRange { path: \"graph.py\", range: Range { start: Position { line: 87, character: 18 }, end: Position { line: 87, character: 24 } } }, kind: None }]"        );
 
         Ok(())
     }

--- a/lsproxy/src/handlers/utils.rs
+++ b/lsproxy/src/handlers/utils.rs
@@ -27,7 +27,7 @@ pub(crate) async fn find_identifier_at_position<'a>(
 ) -> Result<Identifier, PositionError> {
     if let Some(exact_match) = identifiers
         .iter()
-        .find(|i| i.range.contains(position.clone()))
+        .find(|i| i.file_range.contains(position.clone()))
     {
         return Ok(exact_match.clone());
     }
@@ -37,14 +37,17 @@ pub(crate) async fn find_identifier_at_position<'a>(
         .iter()
         .map(|id| {
             let start_line_diff =
-                (id.range.start.line as i32 - position.position.line as i32).abs();
-            let start_char_diff =
-                (id.range.start.character as i32 - position.position.character as i32).abs();
+                (id.file_range.range.start.line as i32 - position.position.line as i32).abs();
+            let start_char_diff = (id.file_range.range.start.character as i32
+                - position.position.character as i32)
+                .abs();
             let start_distance = start_line_diff * 100 + start_char_diff;
 
-            let end_line_diff = (id.range.end.line as i32 - position.position.line as i32).abs();
-            let end_char_diff =
-                (id.range.end.character as i32 - position.position.character as i32).abs();
+            let end_line_diff =
+                (id.file_range.range.end.line as i32 - position.position.line as i32).abs();
+            let end_char_diff = (id.file_range.range.end.character as i32
+                - position.position.character as i32)
+                .abs();
             let end_distance = end_line_diff * 100 + end_char_diff;
 
             (id.clone(), (start_distance.min(end_distance)) as f64)

--- a/lsproxy/src/lib.rs
+++ b/lsproxy/src/lib.rs
@@ -44,7 +44,7 @@ pub fn check_mount_dir() -> std::io::Result<()> {
 #[openapi(
     info(
         title = "lsproxy",
-        version = "0.1.7",
+        version = "0.2.0",
         license(
             name = "Apache-2.0",
             url = "https://www.apache.org/licenses/LICENSE-2.0"

--- a/lsproxy/src/lsp/manager/language_tests/cpp_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/cpp_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api_types::{Position, Range};
 
 #[tokio::test]
 async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,15 +25,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 8,
-                    character: 0,
-                },
-                end: Position {
-                    line: 101,
-                    character: 1,
+                range: Range {
+                    start: Position {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 101,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -46,15 +49,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 15,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 15,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -68,15 +73,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 17,
-                    character: 0,
-                },
-                end: Position {
-                    line: 21,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 17,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 21,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -90,15 +97,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 23,
-                    character: 0,
-                },
-                end: Position {
-                    line: 25,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 23,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 25,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -112,15 +121,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 27,
-                    character: 0,
-                },
-                end: Position {
-                    line: 40,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 27,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 40,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -134,15 +145,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 42,
-                    character: 0,
-                },
-                end: Position {
-                    line: 65,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 42,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 65,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -156,15 +169,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 67,
-                    character: 0,
-                },
-                end: Position {
-                    line: 79,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 67,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 79,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -178,15 +193,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("cpp_classes/astar.cpp"),
-                start: Position {
-                    line: 81,
-                    character: 0,
-                },
-                end: Position {
-                    line: 95,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 81,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 95,
+                        character: 5,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/csharp_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/csharp_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api_types::{FilePosition, FileRange, Position, Range, Symbol, SymbolResponse};
 
 #[tokio::test]
 async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
@@ -24,15 +25,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 2,
-                    character: 0,
-                },
-                end: Position {
-                    line: 87,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 2,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 87,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -46,15 +49,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 36,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 4,
-                    character: 0,
-                },
-                end: Position {
-                    line: 4,
-                    character: 50,
+                range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 50,
+                    },
                 },
             },
         },
@@ -68,15 +73,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 36,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 5,
-                    character: 0,
-                },
-                end: Position {
-                    line: 5,
-                    character: 52,
+                range: Range {
+                    start: Position {
+                        line: 5,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 5,
+                        character: 52,
+                    },
                 },
             },
         },
@@ -90,15 +97,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 36,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 6,
-                    character: 0,
-                },
-                end: Position {
-                    line: 6,
-                    character: 50,
+                range: Range {
+                    start: Position {
+                        line: 6,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 6,
+                        character: 50,
+                    },
                 },
             },
         },
@@ -112,15 +121,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 33,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 7,
-                    character: 0,
-                },
-                end: Position {
-                    line: 7,
-                    character: 39,
+                range: Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 7,
+                        character: 39,
+                    },
                 },
             },
         },
@@ -134,15 +145,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 8,
-                    character: 0,
-                },
-                end: Position {
-                    line: 8,
-                    character: 30,
+                range: Range {
+                    start: Position {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 8,
+                        character: 30,
+                    },
                 },
             },
         },
@@ -156,15 +169,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 29,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 9,
-                    character: 0,
-                },
-                end: Position {
-                    line: 9,
-                    character: 37,
+                range: Range {
+                    start: Position {
+                        line: 9,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 9,
+                        character: 37,
+                    },
                 },
             },
         },
@@ -178,15 +193,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 29,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 10,
-                    character: 37,
+                range: Range {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 10,
+                        character: 37,
+                    },
                 },
             },
         },
@@ -200,15 +217,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 20,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 11,
-                    character: 0,
-                },
-                end: Position {
-                    line: 11,
-                    character: 33,
+                range: Range {
+                    start: Position {
+                        line: 11,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 11,
+                        character: 33,
+                    },
                 },
             },
         },
@@ -222,15 +241,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 27,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 11,
-                    character: 0,
-                },
-                end: Position {
-                    line: 11,
-                    character: 33,
+                range: Range {
+                    start: Position {
+                        line: 11,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 11,
+                        character: 33,
+                    },
                 },
             },
         },
@@ -244,15 +265,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 30,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 12,
-                    character: 0,
-                },
-                end: Position {
-                    line: 12,
-                    character: 36,
+                range: Range {
+                    start: Position {
+                        line: 12,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 12,
+                        character: 36,
+                    },
                 },
             },
         },
@@ -266,15 +289,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 27,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 23,
-                    character: 0,
-                },
-                end: Position {
-                    line: 49,
-                    character: 9,
+                range: Range {
+                    start: Position {
+                        line: 23,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 49,
+                        character: 9,
+                    },
                 },
             },
         },
@@ -288,15 +313,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 51,
-                    character: 0,
-                },
-                end: Position {
-                    line: 76,
-                    character: 9,
+                range: Range {
+                    start: Position {
+                        line: 51,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 76,
+                        character: 9,
+                    },
                 },
             },
         },
@@ -310,15 +337,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 23,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 78,
-                    character: 0,
-                },
-                end: Position {
-                    line: 81,
-                    character: 9,
+                range: Range {
+                    start: Position {
+                        line: 78,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 81,
+                        character: 9,
+                    },
                 },
             },
         },
@@ -332,15 +361,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.cs"),
-                start: Position {
-                    line: 83,
-                    character: 0,
-                },
-                end: Position {
-                    line: 86,
-                    character: 9,
+                range: Range {
+                    start: Position {
+                        line: 83,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 86,
+                        character: 9,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/golang_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/golang_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api_types;
 
 #[tokio::test]
 async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,15 +24,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 5,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 57,
-                    character: 0,
-                },
-                end: Position {
-                    line: 122,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 57,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 122,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -45,15 +48,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 5,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 41,
-                    character: 0,
-                },
-                end: Position {
-                    line: 54,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 41,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 54,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -67,15 +72,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 17,
-                    character: 0,
-                },
-                end: Position {
-                    line: 17,
-                    character: 55,
+                range: api_types::Range {
+                    start: Position {
+                        line: 17,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 17,
+                        character: 55,
+                    },
                 },
             },
         },
@@ -89,15 +96,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 18,
-                    character: 0,
-                },
-                end: Position {
-                    line: 18,
-                    character: 64,
+                range: api_types::Range {
+                    start: Position {
+                        line: 18,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 18,
+                        character: 64,
+                    },
                 },
             },
         },
@@ -111,15 +120,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 30,
-                    character: 0,
-                },
-                end: Position {
-                    line: 38,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 30,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 38,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -133,15 +144,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 24,
-                    character: 0,
-                },
-                end: Position {
-                    line: 29,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 24,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 29,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -155,15 +168,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 19,
-                    character: 0,
-                },
-                end: Position {
-                    line: 23,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 19,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 23,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -177,15 +192,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 5,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 15,
-                    character: 0,
-                },
-                end: Position {
-                    line: 15,
-                    character: 27,
+                range: api_types::Range {
+                    start: Position {
+                        line: 15,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 15,
+                        character: 27,
+                    },
                 },
             },
         },
@@ -199,15 +216,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 5,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: file_path.to_string(),
-                start: Position {
-                    line: 7,
-                    character: 0,
-                },
-                end: Position {
-                    line: 12,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 12,
+                        character: 1,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/java_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/java_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::api_types::{Position, Range as ApiRange};
+use lsp_types::{Position as LspPosition, Range as LspRange};
 
 #[tokio::test]
 #[ignore = "Java hangs in tests"]
@@ -24,15 +26,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 13,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 96,
-                    character: 21,
+                range: ApiRange {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 96,
+                        character: 21,
+                    },
                 },
             },
         },
@@ -46,15 +50,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 22,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 39,
-                    character: 0,
-                },
-                end: Position {
-                    line: 59,
-                    character: 5,
+                range: ApiRange {
+                    start: Position {
+                        line: 39,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 59,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -68,15 +74,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 61,
-                    character: 0,
-                },
-                end: Position {
-                    line: 89,
-                    character: 41,
+                range: ApiRange {
+                    start: Position {
+                        line: 61,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 89,
+                        character: 41,
+                    },
                 },
             },
         },
@@ -90,15 +98,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 55,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 93,
-                    character: 0,
-                },
-                end: Position {
-                    line: 95,
-                    character: 41,
+                range: ApiRange {
+                    start: Position {
+                        line: 93,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 95,
+                        character: 41,
+                    },
                 },
             },
         },
@@ -112,15 +122,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 59,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 98,
-                    character: 0,
-                },
-                end: Position {
-                    line: 136,
-                    character: 5,
+                range: ApiRange {
+                    start: Position {
+                        line: 98,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 136,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -134,15 +146,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 20,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 138,
-                    character: 0,
-                },
-                end: Position {
-                    line: 140,
-                    character: 5,
+                range: ApiRange {
+                    start: Position {
+                        line: 138,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 140,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -167,7 +181,7 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
     let references = manager
         .find_references(
             file_path,
-            lsp_types::Position {
+            LspPosition {
                 line: 10,
                 character: 13,
             },
@@ -177,12 +191,12 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
     let expected = vec![
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/java/AStar.java").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 10,
                     character: 13,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 10,
                     character: 18,
                 },
@@ -190,12 +204,12 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/java/AStar.java").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 111,
                     character: 8,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 111,
                     character: 13,
                 },
@@ -203,12 +217,12 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/java/AStar.java").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 111,
                     character: 23,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 111,
                     character: 28,
                 },
@@ -231,7 +245,7 @@ async fn test_definition() -> Result<(), Box<dyn std::error::Error>> {
     let definition_response = manager
         .find_definition(
             "AStar.java",
-            lsp_types::Position {
+            LspPosition {
                 line: 111,
                 character: 8,
             },
@@ -245,12 +259,12 @@ async fn test_definition() -> Result<(), Box<dyn std::error::Error>> {
     };
     let expected = vec![Location {
         uri: Url::parse("file:///mnt/lsproxy_root/sample_project/java/AStar.java").unwrap(),
-        range: Range {
-            start: lsp_types::Position {
+        range: LspRange {
+            start: LspPosition {
                 line: 10,
                 character: 13,
             },
-            end: lsp_types::Position {
+            end: LspPosition {
                 line: 10,
                 character: 18,
             },

--- a/lsproxy/src/lsp/manager/language_tests/js_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/js_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api_types::{Position, Range};
 
 #[tokio::test]
 async fn test_start_manager() -> Result<(), Box<dyn std::error::Error>> {
@@ -43,7 +44,7 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
     let expected = vec![
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/js/astar_search.js")?,
-            range: Range {
+            range: lsp_types::Range {
                 start: lsp_types::Position {
                     line: 0,
                     character: 9,
@@ -56,7 +57,7 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/js/astar_search.js")?,
-            range: Range {
+            range: lsp_types::Range {
                 start: lsp_types::Position {
                     line: 10,
                     character: 21,
@@ -69,7 +70,7 @@ async fn test_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/js/astar_search.js")?,
-            range: Range {
+            range: lsp_types::Range {
                 start: lsp_types::Position {
                     line: 40,
                     character: 25,
@@ -112,7 +113,7 @@ async fn test_definition() -> Result<(), Box<dyn std::error::Error>> {
         definitions,
         vec![Location {
             uri: Url::parse("file:///usr/lib/node_modules/typescript/lib/lib.es5.d.ts")?,
-            range: Range {
+            range: lsp_types::Range {
                 start: lsp_types::Position {
                     line: 681,
                     character: 4
@@ -152,15 +153,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("astar_search.js"),
-                start: Position {
-                    line: 0,
-                    character: 0,
-                },
-                end: Position {
-                    line: 2,
-                    character: 1,
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -174,15 +177,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 9,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("astar_search.js"),
-                start: Position {
-                    line: 4,
-                    character: 0,
-                },
-                end: Position {
-                    line: 58,
-                    character: 1,
+                range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 58,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -196,15 +201,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 16,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("astar_search.js"),
-                start: Position {
-                    line: 17,
-                    character: 0,
-                },
-                end: Position {
-                    line: 26,
-                    character: 9,
+                range: Range {
+                    start: Position {
+                        line: 17,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 26,
+                        character: 9,
+                    },
                 },
             },
         },
@@ -218,15 +225,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("astar_search.js"),
-                start: Position {
-                    line: 60,
-                    character: 0,
-                },
-                end: Position {
-                    line: 69,
-                    character: 1,
+                range: Range {
+                    start: Position {
+                        line: 60,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 69,
+                        character: 1,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/php_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/php_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::api_types::{Position as ApiPosition, Range as ApiRange};
+use lsp_types::{Position as LspPosition, Range as LspRange};
 
 #[tokio::test]
 async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,20 +20,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("class"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 6,
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 6,
-                    character: 0,
-                },
-                end: Position {
-                    line: 94,
-                    character: 1,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 6,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 94,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -40,20 +44,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("method"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 18,
                     character: 20,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 18,
-                    character: 0,
-                },
-                end: Position {
-                    line: 24,
-                    character: 5,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 18,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 24,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -62,20 +68,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("method"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 50,
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 50,
-                    character: 0,
-                },
-                end: Position {
-                    line: 80,
-                    character: 5,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 50,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 80,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -84,20 +92,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 8,
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 8,
-                    character: 0,
-                },
-                end: Position {
-                    line: 8,
-                    character: 31,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 8,
+                        character: 31,
+                    },
                 },
             },
         },
@@ -106,20 +116,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 16,
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 16,
-                    character: 0,
-                },
-                end: Position {
-                    line: 16,
-                    character: 23,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 16,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 16,
+                        character: 23,
+                    },
                 },
             },
         },
@@ -128,20 +140,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("method"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 82,
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 82,
-                    character: 0,
-                },
-                end: Position {
-                    line: 84,
-                    character: 5,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 82,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 84,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -150,20 +164,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("method"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 86,
                     character: 21,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 86,
-                    character: 0,
-                },
-                end: Position {
-                    line: 93,
-                    character: 5,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 86,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 93,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -172,20 +188,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("method"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 26,
                     character: 20,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 26,
-                    character: 0,
-                },
-                end: Position {
-                    line: 48,
-                    character: 5,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 26,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 48,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -194,20 +212,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 10,
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 10,
-                    character: 24,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 10,
+                        character: 24,
+                    },
                 },
             },
         },
@@ -216,20 +236,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 11,
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 11,
-                    character: 0,
-                },
-                end: Position {
-                    line: 11,
-                    character: 22,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 11,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 11,
+                        character: 22,
+                    },
                 },
             },
         },
@@ -238,20 +260,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 7,
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 7,
-                    character: 0,
-                },
-                end: Position {
-                    line: 7,
-                    character: 29,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 7,
+                        character: 29,
+                    },
                 },
             },
         },
@@ -260,20 +284,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 9,
                     character: 19,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 9,
-                    character: 0,
-                },
-                end: Position {
-                    line: 9,
-                    character: 29,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 9,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 9,
+                        character: 29,
+                    },
                 },
             },
         },
@@ -282,20 +308,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 14,
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 14,
-                    character: 0,
-                },
-                end: Position {
-                    line: 14,
-                    character: 22,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 14,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 14,
+                        character: 22,
+                    },
                 },
             },
         },
@@ -304,20 +332,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 12,
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 12,
-                    character: 0,
-                },
-                end: Position {
-                    line: 12,
-                    character: 24,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 12,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 12,
+                        character: 24,
+                    },
                 },
             },
         },
@@ -326,20 +356,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 15,
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 15,
-                    character: 0,
-                },
-                end: Position {
-                    line: 15,
-                    character: 22,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 15,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 15,
+                        character: 22,
+                    },
                 },
             },
         },
@@ -348,20 +380,22 @@ async fn test_php_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
             kind: String::from("property"),
             identifier_position: FilePosition {
                 path: String::from("AStar.php"),
-                position: Position {
+                position: ApiPosition {
                     line: 13,
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.php"),
-                start: Position {
-                    line: 13,
-                    character: 0,
-                },
-                end: Position {
-                    line: 13,
-                    character: 24,
+                range: ApiRange {
+                    start: ApiPosition {
+                        line: 13,
+                        character: 0,
+                    },
+                    end: ApiPosition {
+                        line: 13,
+                        character: 24,
+                    },
                 },
             },
         },
@@ -385,7 +419,7 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
     let references = manager
         .find_references(
             file_path,
-            lsp_types::Position {
+            LspPosition {
                 line: 3,
                 character: 6,
             },
@@ -395,12 +429,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
     let expected = vec![
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/AStar.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 11,
                     character: 12,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 11,
                     character: 16,
                 },
@@ -408,12 +442,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/AStar.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 23,
                     character: 25,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 23,
                     character: 29,
                 },
@@ -421,12 +455,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/AStar.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 57,
                     character: 28,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 57,
                     character: 32,
                 },
@@ -434,12 +468,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/AStar.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 86,
                     character: 53,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 86,
                     character: 57,
                 },
@@ -447,12 +481,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/Node.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 3,
                     character: 0,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 23,
                     character: 1,
                 },
@@ -460,12 +494,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/Node.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 4,
                     character: 12,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 4,
                     character: 16,
                 },
@@ -473,12 +507,12 @@ async fn test_php_references() -> Result<(), Box<dyn std::error::Error>> {
         },
         Location {
             uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/Node.php").unwrap(),
-            range: Range {
-                start: lsp_types::Position {
+            range: LspRange {
+                start: LspPosition {
                     line: 10,
                     character: 33,
                 },
-                end: lsp_types::Position {
+                end: LspPosition {
                     line: 10,
                     character: 37,
                 },
@@ -500,7 +534,7 @@ async fn test_php_definition() -> Result<(), Box<dyn std::error::Error>> {
     let definition_response = manager
         .find_definition(
             "main.php",
-            lsp_types::Position {
+            LspPosition {
                 line: 20,
                 character: 13,
             },
@@ -514,12 +548,12 @@ async fn test_php_definition() -> Result<(), Box<dyn std::error::Error>> {
     };
     let expected = vec![Location {
         uri: Url::parse("file:///mnt/lsproxy_root/sample_project/php/AStar.php").unwrap(),
-        range: Range {
-            start: lsp_types::Position {
+        range: LspRange {
+            start: LspPosition {
                 line: 6,
                 character: 0,
             },
-            end: lsp_types::Position {
+            end: LspPosition {
                 line: 94,
                 character: 1,
             },

--- a/lsproxy/src/lsp/manager/language_tests/python_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/python_tests.rs
@@ -1,3 +1,5 @@
+use crate::api_types;
+
 use super::*;
 
 #[tokio::test]
@@ -46,15 +48,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("main.py"),
-                start: Position {
-                    line: 5,
-                    character: 0,
-                },
-                end: Position {
-                    line: 12,
-                    character: 14,
+                range: api_types::Range {
+                    start: Position {
+                        line: 5,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 12,
+                        character: 14,
+                    },
                 },
             },
         },
@@ -68,15 +72,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("main.py"),
-                start: Position {
-                    line: 14,
-                    character: 0,
-                },
-                end: Position {
-                    line: 19,
-                    character: 28,
+                range: api_types::Range {
+                    start: Position {
+                        line: 14,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 19,
+                        character: 28,
+                    },
                 },
             },
         },
@@ -90,15 +96,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("main.py"),
-                start: Position {
-                    line: 15,
-                    character: 0,
-                },
-                end: Position {
-                    line: 15,
-                    character: 24,
+                range: api_types::Range {
+                    start: Position {
+                        line: 15,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 15,
+                        character: 24,
+                    },
                 },
             },
         },
@@ -132,15 +140,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 4,
-                    character: 0,
-                },
-                end: Position {
-                    line: 5,
-                    character: 8,
+                range: api_types::Range {
+                    start: Position {
+                        line: 4,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 5,
+                        character: 8,
+                    },
                 },
             },
         },
@@ -154,15 +164,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 7,
-                    character: 0,
-                },
-                end: Position {
-                    line: 10,
-                    character: 25,
+                range: api_types::Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 10,
+                        character: 25,
+                    },
                 },
             },
         },
@@ -176,15 +188,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 8,
-                    character: 0,
-                },
-                end: Position {
-                    line: 8,
-                    character: 23,
+                range: api_types::Range {
+                    start: Position {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 8,
+                        character: 23,
+                    },
                 },
             },
         },
@@ -198,15 +212,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 9,
-                    character: 0,
-                },
-                end: Position {
-                    line: 9,
-                    character: 25,
+                range: api_types::Range {
+                    start: Position {
+                        line: 9,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 9,
+                        character: 25,
+                    },
                 },
             },
         },
@@ -220,15 +236,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 10,
-                    character: 25,
+                range: api_types::Range {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 10,
+                        character: 25,
+                    },
                 },
             },
         },
@@ -242,15 +260,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 6,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 12,
-                    character: 0,
-                },
-                end: Position {
-                    line: 88,
-                    character: 16,
+                range: api_types::Range {
+                    start: Position {
+                        line: 12,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 88,
+                        character: 16,
+                    },
                 },
             },
         },
@@ -264,15 +284,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 13,
-                    character: 0,
-                },
-                end: Position {
-                    line: 20,
-                    character: 10,
+                range: api_types::Range {
+                    start: Position {
+                        line: 13,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 20,
+                        character: 10,
+                    },
                 },
             },
         },
@@ -286,15 +308,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 22,
-                    character: 0,
-                },
-                end: Position {
-                    line: 24,
-                    character: 29,
+                range: api_types::Range {
+                    start: Position {
+                        line: 22,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 24,
+                        character: 29,
+                    },
                 },
             },
         },
@@ -308,15 +332,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 26,
-                    character: 0,
-                },
-                end: Position {
-                    line: 31,
-                    character: 16,
+                range: api_types::Range {
+                    start: Position {
+                        line: 26,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 31,
+                        character: 16,
+                    },
                 },
             },
         },
@@ -330,15 +356,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 33,
-                    character: 0,
-                },
-                end: Position {
-                    line: 35,
-                    character: 50,
+                range: api_types::Range {
+                    start: Position {
+                        line: 33,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 35,
+                        character: 50,
+                    },
                 },
             },
         },
@@ -352,15 +380,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 37,
-                    character: 0,
-                },
-                end: Position {
-                    line: 41,
-                    character: 43,
+                range: api_types::Range {
+                    start: Position {
+                        line: 37,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 41,
+                        character: 43,
+                    },
                 },
             },
         },
@@ -374,15 +404,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 39,
-                    character: 0,
-                },
-                end: Position {
-                    line: 39,
-                    character: 47,
+                range: api_types::Range {
+                    start: Position {
+                        line: 39,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 39,
+                        character: 47,
+                    },
                 },
             },
         },
@@ -396,15 +428,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 40,
-                    character: 0,
-                },
-                end: Position {
-                    line: 40,
-                    character: 49,
+                range: api_types::Range {
+                    start: Position {
+                        line: 40,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 40,
+                        character: 49,
+                    },
                 },
             },
         },
@@ -418,15 +452,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 43,
-                    character: 0,
-                },
-                end: Position {
-                    line: 65,
-                    character: 34,
+                range: api_types::Range {
+                    start: Position {
+                        line: 43,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 65,
+                        character: 34,
+                    },
                 },
             },
         },
@@ -440,15 +476,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 12,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 57,
-                    character: 0,
-                },
-                end: Position {
-                    line: 57,
-                    character: 46,
+                range: api_types::Range {
+                    start: Position {
+                        line: 57,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 57,
+                        character: 46,
+                    },
                 },
             },
         },
@@ -462,15 +500,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 12,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 59,
-                    character: 0,
-                },
-                end: Position {
-                    line: 59,
-                    character: 47,
+                range: api_types::Range {
+                    start: Position {
+                        line: 59,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 59,
+                        character: 47,
+                    },
                 },
             },
         },
@@ -484,15 +524,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 12,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 61,
-                    character: 0,
-                },
-                end: Position {
-                    line: 61,
-                    character: 47,
+                range: api_types::Range {
+                    start: Position {
+                        line: 61,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 61,
+                        character: 47,
+                    },
                 },
             },
         },
@@ -506,15 +548,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 67,
-                    character: 0,
-                },
-                end: Position {
-                    line: 73,
-                    character: 57,
+                range: api_types::Range {
+                    start: Position {
+                        line: 67,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 73,
+                        character: 57,
+                    },
                 },
             },
         },
@@ -528,15 +572,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 69,
-                    character: 0,
-                },
-                end: Position {
-                    line: 69,
-                    character: 13,
+                range: api_types::Range {
+                    start: Position {
+                        line: 69,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 69,
+                        character: 13,
+                    },
                 },
             },
         },
@@ -550,15 +596,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 70,
-                    character: 0,
-                },
-                end: Position {
-                    line: 70,
-                    character: 14,
+                range: api_types::Range {
+                    start: Position {
+                        line: 70,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 70,
+                        character: 14,
+                    },
                 },
             },
         },
@@ -572,15 +620,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 71,
-                    character: 0,
-                },
-                end: Position {
-                    line: 71,
-                    character: 36,
+                range: api_types::Range {
+                    start: Position {
+                        line: 71,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 71,
+                        character: 36,
+                    },
                 },
             },
         },
@@ -594,15 +644,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 72,
-                    character: 0,
-                },
-                end: Position {
-                    line: 72,
-                    character: 36,
+                range: api_types::Range {
+                    start: Position {
+                        line: 72,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 72,
+                        character: 36,
+                    },
                 },
             },
         },
@@ -616,15 +668,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 75,
-                    character: 0,
-                },
-                end: Position {
-                    line: 88,
-                    character: 16,
+                range: api_types::Range {
+                    start: Position {
+                        line: 75,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 88,
+                        character: 16,
+                    },
                 },
             },
         },
@@ -638,15 +692,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 8,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 77,
-                    character: 0,
-                },
-                end: Position {
-                    line: 77,
-                    character: 14,
+                range: api_types::Range {
+                    start: Position {
+                        line: 77,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 77,
+                        character: 14,
+                    },
                 },
             },
         },
@@ -660,15 +716,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 12,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 82,
-                    character: 0,
-                },
-                end: Position {
-                    line: 82,
-                    character: 28,
+                range: api_types::Range {
+                    start: Position {
+                        line: 82,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 82,
+                        character: 28,
+                    },
                 },
             },
         },
@@ -682,15 +740,17 @@ async fn test_file_symbols_decorators() -> Result<(), Box<dyn std::error::Error>
                     character: 12,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("graph.py"),
-                start: Position {
-                    line: 83,
-                    character: 0,
-                },
-                end: Position {
-                    line: 83,
-                    character: 28,
+                range: api_types::Range {
+                    start: Position {
+                        line: 83,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 83,
+                        character: 28,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/rust_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/rust_tests.rs
@@ -1,3 +1,5 @@
+use crate::api_types;
+
 use super::*;
 
 #[tokio::test]
@@ -23,15 +25,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 11,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/map.rs"),
-                start: Position {
-                    line: 0,
-                    character: 0,
-                },
-                end: Position {
-                    line: 4,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -45,15 +49,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 5,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/map.rs"),
-                start: Position {
-                    line: 6,
-                    character: 0,
-                },
-                end: Position {
-                    line: 24,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 6,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 24,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -67,15 +73,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 11,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/map.rs"),
-                start: Position {
-                    line: 21,
-                    character: 0,
-                },
-                end: Position {
-                    line: 23,
-                    character: 5,
+                range: api_types::Range {
+                    start: Position {
+                        line: 21,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 23,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -89,15 +97,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 11,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/map.rs"),
-                start: Position {
-                    line: 7,
-                    character: 0,
-                },
-                end: Position {
-                    line: 19,
-                    character: 5,
+                range: api_types::Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 19,
+                        character: 5,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/tsx_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/tsx_tests.rs
@@ -1,3 +1,5 @@
+use crate::api_types;
+
 use super::*;
 
 #[tokio::test]
@@ -23,15 +25,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 13,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 15,
-                    character: 0,
-                },
-                end: Position {
-                    line: 92,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 15,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 92,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -45,15 +49,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 10,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 8,
-                    character: 0,
-                },
-                end: Position {
-                    line: 13,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 13,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -67,15 +73,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 14,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 36,
-                    character: 0,
-                },
-                end: Position {
-                    line: 36,
-                    character: 19,
+                range: api_types::Range {
+                    start: Position {
+                        line: 36,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 36,
+                        character: 19,
+                    },
                 },
             },
         },
@@ -89,15 +97,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 10,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 35,
-                    character: 0,
-                },
-                end: Position {
-                    line: 41,
-                    character: 5,
+                range: api_types::Range {
+                    start: Position {
+                        line: 35,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 41,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -111,15 +121,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 10,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 65,
-                    character: 0,
-                },
-                end: Position {
-                    line: 69,
-                    character: 5,
+                range: api_types::Range {
+                    start: Position {
+                        line: 65,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 69,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -133,15 +145,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 14,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 58,
-                    character: 0,
-                },
-                end: Position {
-                    line: 58,
-                    character: 21,
+                range: api_types::Range {
+                    start: Position {
+                        line: 58,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 58,
+                        character: 21,
+                    },
                 },
             },
         },
@@ -155,15 +169,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 14,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 37,
-                    character: 0,
-                },
-                end: Position {
-                    line: 37,
-                    character: 21,
+                range: api_types::Range {
+                    start: Position {
+                        line: 37,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 37,
+                        character: 21,
+                    },
                 },
             },
         },
@@ -177,15 +193,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 18,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 45,
-                    character: 0,
-                },
-                end: Position {
-                    line: 45,
-                    character: 23,
+                range: api_types::Range {
+                    start: Position {
+                        line: 45,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 45,
+                        character: 23,
+                    },
                 },
             },
         },
@@ -199,15 +217,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 10,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/PathfinderDisplay.tsx"),
-                start: Position {
-                    line: 55,
-                    character: 0,
-                },
-                end: Position {
-                    line: 63,
-                    character: 5,
+                range: api_types::Range {
+                    start: Position {
+                        line: 55,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 63,
+                        character: 5,
+                    },
                 },
             },
         },

--- a/lsproxy/src/lsp/manager/language_tests/typescript_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/typescript_tests.rs
@@ -1,3 +1,5 @@
+use crate::api_types;
+
 use super::*;
 
 #[tokio::test]
@@ -23,15 +25,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 13,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/node.ts"),
-                start: Position {
-                    line: 0,
-                    character: 0,
-                },
-                end: Position {
-                    line: 14,
-                    character: 1,
+                range: api_types::Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 14,
+                        character: 1,
+                    },
                 },
             },
         },
@@ -45,15 +49,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/node.ts"),
-                start: Position {
-                    line: 1,
-                    character: 0,
-                },
-                end: Position {
-                    line: 7,
-                    character: 8,
+                range: api_types::Range {
+                    start: Position {
+                        line: 1,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 7,
+                        character: 8,
+                    },
                 },
             },
         },
@@ -67,15 +73,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/node.ts"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 10,
-                    character: 37,
+                range: api_types::Range {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 10,
+                        character: 37,
+                    },
                 },
             },
         },
@@ -89,15 +97,17 @@ async fn test_file_symbols() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("src/node.ts"),
-                start: Position {
-                    line: 13,
-                    character: 0,
-                },
-                end: Position {
-                    line: 13,
-                    character: 57,
+                range: api_types::Range {
+                    start: Position {
+                        line: 13,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 13,
+                        character: 57,
+                    },
                 },
             },
         },

--- a/lsproxy/tests/java_test.rs
+++ b/lsproxy/tests/java_test.rs
@@ -1,5 +1,6 @@
 use lsproxy::api_types::{
-    set_global_mount_dir, FilePosition, FileRange, HealthResponse, Position, Symbol, SymbolResponse,
+    set_global_mount_dir, FilePosition, FileRange, HealthResponse, Position, Range, Symbol,
+    SymbolResponse,
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
@@ -107,15 +108,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 13,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 10,
-                    character: 0,
-                },
-                end: Position {
-                    line: 96,
-                    character: 21,
+                range: Range {
+                    start: Position {
+                        line: 10,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 96,
+                        character: 21,
+                    },
                 },
             },
         },
@@ -129,15 +132,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 22,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 39,
-                    character: 0,
-                },
-                end: Position {
-                    line: 59,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 39,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 59,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -151,15 +156,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 17,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 61,
-                    character: 0,
-                },
-                end: Position {
-                    line: 89,
-                    character: 41,
+                range: Range {
+                    start: Position {
+                        line: 61,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 89,
+                        character: 41,
+                    },
                 },
             },
         },
@@ -173,15 +180,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 55,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 93,
-                    character: 0,
-                },
-                end: Position {
-                    line: 95,
-                    character: 41,
+                range: Range {
+                    start: Position {
+                        line: 93,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 95,
+                        character: 41,
+                    },
                 },
             },
         },
@@ -195,15 +204,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 59,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 98,
-                    character: 0,
-                },
-                end: Position {
-                    line: 136,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 98,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 136,
+                        character: 5,
+                    },
                 },
             },
         },
@@ -217,15 +228,17 @@ fn test_server_integration_java() -> Result<(), Box<dyn std::error::Error>> {
                     character: 20,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("AStar.java"),
-                start: Position {
-                    line: 138,
-                    character: 0,
-                },
-                end: Position {
-                    line: 140,
-                    character: 5,
+                range: Range {
+                    start: Position {
+                        line: 138,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 140,
+                        character: 5,
+                    },
                 },
             },
         },

--- a/lsproxy/tests/python_test.rs
+++ b/lsproxy/tests/python_test.rs
@@ -1,5 +1,6 @@
 use lsproxy::api_types::{
-    set_global_mount_dir, FilePosition, FileRange, HealthResponse, Position, Symbol, SymbolResponse,
+    set_global_mount_dir, FilePosition, FileRange, HealthResponse, Position, Range, Symbol,
+    SymbolResponse,
 };
 use lsproxy::{initialize_app_state, run_server};
 use reqwest;
@@ -113,15 +114,17 @@ fn test_server_integration_python() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("main.py"),
-                start: Position {
-                    line: 5,
-                    character: 0,
-                },
-                end: Position {
-                    line: 12,
-                    character: 14,
+                range: Range {
+                    start: Position {
+                        line: 5,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 12,
+                        character: 14,
+                    },
                 },
             },
         },
@@ -135,15 +138,17 @@ fn test_server_integration_python() -> Result<(), Box<dyn std::error::Error>> {
                     character: 4,
                 },
             },
-            range: FileRange {
+            file_range: FileRange {
                 path: String::from("main.py"),
-                start: Position {
-                    line: 14,
-                    character: 0,
-                },
-                end: Position {
-                    line: 19,
-                    character: 28,
+                range: Range {
+                    start: Position {
+                        line: 14,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 19,
+                        character: 28,
+                    },
                 },
             },
         },

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache-2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.1.7"
+    "version": "0.2.0"
   },
   "servers": [
     {

--- a/openapi.json
+++ b/openapi.json
@@ -278,7 +278,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FileRange"
+                "$ref": "#/components/schemas/ReadSourceCodeRequest"
               }
             }
           },
@@ -392,22 +392,17 @@
         "description": "A range within a specific file, defined by start and end positions",
         "required": [
           "path",
-          "start",
-          "end"
+          "range"
         ],
         "properties": {
-          "end": {
-            "$ref": "#/components/schemas/Position",
-            "description": "The end position of the range."
-          },
           "path": {
             "type": "string",
             "description": "The path to the file.",
             "example": "src/main.py"
           },
-          "start": {
-            "$ref": "#/components/schemas/Position",
-            "description": "The start position of the range."
+          "range": {
+            "$ref": "#/components/schemas/Range",
+            "description": "The range within the file"
           }
         }
       },
@@ -558,9 +553,12 @@
         "type": "object",
         "required": [
           "name",
-          "range"
+          "file_range"
         ],
         "properties": {
+          "file_range": {
+            "$ref": "#/components/schemas/FileRange"
+          },
           "kind": {
             "type": [
               "string",
@@ -569,9 +567,6 @@
           },
           "name": {
             "type": "string"
-          },
-          "range": {
-            "$ref": "#/components/schemas/FileRange"
           }
         }
       },
@@ -610,6 +605,47 @@
             "description": "0-indexed line number.",
             "example": 10,
             "minimum": 0
+          }
+        }
+      },
+      "Range": {
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "properties": {
+          "end": {
+            "$ref": "#/components/schemas/Position",
+            "description": "The end position of the range."
+          },
+          "start": {
+            "$ref": "#/components/schemas/Position",
+            "description": "The start position of the range."
+          }
+        }
+      },
+      "ReadSourceCodeRequest": {
+        "type": "object",
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the file, relative to the workspace root",
+            "example": "src/main.py"
+          },
+          "range": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Range",
+                "description": "Optional range within the file to read"
+              }
+            ]
           }
         }
       },
@@ -725,9 +761,13 @@
           "name",
           "kind",
           "identifier_position",
-          "range"
+          "file_range"
         ],
         "properties": {
+          "file_range": {
+            "$ref": "#/components/schemas/FileRange",
+            "description": "The full range of the symbol."
+          },
           "identifier_position": {
             "$ref": "#/components/schemas/FilePosition",
             "description": "The start position of the symbol's identifier."
@@ -741,10 +781,6 @@
             "type": "string",
             "description": "The name of the symbol.",
             "example": "User"
-          },
-          "range": {
-            "$ref": "#/components/schemas/FileRange",
-            "description": "The full range of the symbol."
           }
         }
       },
@@ -756,9 +792,13 @@
             "name",
             "kind",
             "identifier_position",
-            "range"
+            "file_range"
           ],
           "properties": {
+            "file_range": {
+              "$ref": "#/components/schemas/FileRange",
+              "description": "The full range of the symbol."
+            },
             "identifier_position": {
               "$ref": "#/components/schemas/FilePosition",
               "description": "The start position of the symbol's identifier."
@@ -772,10 +812,6 @@
               "type": "string",
               "description": "The name of the symbol.",
               "example": "User"
-            },
-            "range": {
-              "$ref": "#/components/schemas/FileRange",
-              "description": "The full range of the symbol."
             }
           }
         }

--- a/release/install-lsproxy.sh
+++ b/release/install-lsproxy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-LSPROXY_VERSION="0.3.6"
+LSPROXY_VERSION="0.4.0"
 
 # Initialize variables
 TARGET_USER=""


### PR DESCRIPTION
## **User description**
This commit introduces a more structured approach to representing file ranges by adding a nested `Range` type to `FileRange`. The changes include:

 Make range optional for read source code
 https://github.com/agentic-labs/lsproxy/issues/64


___

## **CodeAnt-AI Description**
- Refactored the `FileRange` structure to include a nested `Range` type, enhancing the code's modularity and readability.
- Updated multiple test files to accommodate the new `file_range` structure, ensuring compatibility and correctness.
- Adjusted imports and references to use the new `api_types::Range` and `lsp_types::Range` where appropriate.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_tests.rs</strong><dd><code>Refactor Python tests to use nested `Range` type in `FileRange`</code></dd></summary>
<hr>

lsproxy/src/lsp/manager/language_tests/python_tests.rs
<li>Introduced <code>api_types::Range</code> as a nested type within <code>FileRange</code>.<br> <li> Updated test cases to use <code>file_range</code> instead of <code>range</code>.<br> <li> Adjusted imports to include <code>api_types</code>.


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/125/files#diff-aec66ac479a2d25f5e27ce6c818921883fb912ee5b49c7b88f23f0c201866846">+292/-232</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>js_tests.rs</strong><dd><code>Update JS tests to use consistent `Range` type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lsproxy/src/lsp/manager/language_tests/js_tests.rs
<li>Changed <code>Range</code> to <code>lsp_types::Range</code> for consistency.<br> <li> Updated test cases to use <code>file_range</code> instead of <code>range</code>.<br> <li> Added import for <code>Position</code> and <code>Range</code> from <code>api_types</code>.


</details>
    

  </td>
  <td><a href="https://github.com/agentic-labs/lsproxy/pull/125/files#diff-94f787759a29e57e5008962b0b07e29a4879e0da9c79f9b27b4414f774d11d0e">+45/-36</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
