### PR TITLE
JavaScript ast-grep rules to match assignment of function to pair

### DIFF
--- a/lsproxy/Cargo.toml
+++ b/lsproxy/Cargo.toml
@@ -23,8 +23,8 @@ serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
 tokio = { version = "1.0", features = ["full", "process"] }
-utoipa = { git = "https://github.com/juhaku/utoipa.git", rev = "cecda0531bf7d90800af66b186055932ee730526", features = ["actix_extras"] }
-utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "cecda0531bf7d90800af66b186055932ee730526", features = ["actix-web"] }
+utoipa = { version = "5.4", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["actix-web"] }
 rand = "0.8"
 async-trait = "0.1"
 futures = "0.3"

--- a/lsproxy/src/ast_grep/symbol/rules/javascript/function.yml
+++ b/lsproxy/src/ast_grep/symbol/rules/javascript/function.yml
@@ -8,6 +8,11 @@ rule:
         any:
           - kind: function_declaration
           - kind: function_expression
+            not:
+              inside:
+                any:
+                  - kind: assignment_expression
+                  - kind: pair
           - kind: generator_function
           - kind: generator_function_declaration
           - kind: variable_declarator
@@ -22,9 +27,18 @@ rule:
         pattern: $CONTEXT
     - kind: property_identifier
       inside:
-        kind: pair
-        has:
-          any:
-            - kind: function_expression
-            - kind: arrow_function
-        pattern: $CONTEXT
+        any:
+          - kind: pair
+            has:
+              any:
+                - kind: function_expression
+                - kind: arrow_function
+            pattern: $CONTEXT
+          - kind: member_expression
+            inside:
+              kind: assignment_expression
+              has:
+                any:
+                  - kind: arrow_function
+                  - kind: function_expression
+              pattern: $CONTEXT

--- a/lsproxy/src/lsp/manager/language_tests/js_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/js_tests.rs
@@ -503,6 +503,54 @@ async fn test_file_symbols_functions_js() -> Result<(), Box<dyn std::error::Erro
                 },
             },
         },
+        Symbol {
+            name: "exampleFunc".to_string(),
+            kind: "function".to_string(),
+            identifier_position: FilePosition {
+                path: file_path.to_string(),
+                position: Position {
+                    line: 26,
+                    character: 15,
+                },
+            },
+            file_range: FileRange {
+                path: file_path.to_string(),
+                range: Range {
+                    start: Position {
+                        line: 26,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 28,
+                        character: 1,
+                    },
+                },
+            },
+        },
+        Symbol {
+            name: "exampleFunc".to_string(),
+            kind: "function".to_string(),
+            identifier_position: FilePosition {
+                path: file_path.to_string(),
+                position: Position {
+                    line: 31,
+                    character: 15,
+                },
+            },
+            file_range: FileRange {
+                path: file_path.to_string(),
+                range: Range {
+                    start: Position {
+                        line: 31,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 33,
+                        character: 1,
+                    },
+                },
+            },
+        },
     ];
 
     symbol_response.sort_by_key(|s| s.name.clone());

--- a/lsproxy/src/lsp/manager/language_tests/php_tests.rs
+++ b/lsproxy/src/lsp/manager/language_tests/php_tests.rs
@@ -530,6 +530,8 @@ async fn test_php_definition() -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .ok_or("Manager is not initialized")?;
 
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
     let definition_response = manager
         .find_definition(
             "main.php",

--- a/sample_project/js/functions.js
+++ b/sample_project/js/functions.js
@@ -22,3 +22,13 @@ const topLevelFuncExprConst = function namedInnerFuncExpr() {};
 // Assignment expression with an arrow function
 let assignedArrowLet;
 assignedArrowLet = () => {};
+
+// Assignment to module.exports with a named function expression
+module.exports.exampleFunc = function exampleFuncInner() {
+  console.log("hello");
+};
+
+// Assignment to module.exports with an arrow function
+module.exports.exampleFunc = () => {
+  console.log("hello");
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ set -e  # Exit immediately if a command exits with a non-zero status
 # Build the application using the build Dockerfile
 docker build -t lsproxy-dev lsproxy
 
-if ! docker run --rm -v "$(pwd)/lsproxy":/usr/src/app -v "$(pwd)":/mnt/lsproxy_root lsproxy-dev cargo test $@; then
+if ! docker run --rm -v "$(pwd)/lsproxy":/usr/src/app -v "$(pwd)":/mnt/lsproxy_root lsproxy-dev cargo test --target-dir /tmp/target $@; then
     echo "Tests failed. Exiting."
     exit 1
 fi


### PR DESCRIPTION
Previously `ast-grep` rules were not able to match these two cases:

```javascript
module.exports.exampleFunc = function exampleFuncInner() {
  console.log("hello");
};
```
(`exampleFuncInner` would be matched, but we want `exampleFunc`) 

```javascript
module.exports.exampleFunc = () => {
  console.log("hello");
}
```
(wouldn't be matched)

### Changes

- Modify `ast-grep` rules
- Add tests
- Fix PHP tests failing